### PR TITLE
Do set albumpath to an empty value if an error is thrown

### DIFF
--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -43,6 +43,9 @@
 		 * @param {string|undefined} errorMessage
 		 */
 		init: function (albumPath, errorMessage) {
+			// Remove all null-bytes from the path
+			albumPath = albumPath.replace(/\0/g, '');
+
 			// Only do it when the app is initialised
 			if (this.requestId === -1) {
 				this._initButtons();

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -37,14 +37,32 @@
 		},
 
 		/**
+		 * @param {string} path
+		 * @returns {boolean}
+		 */
+		_isValidPath: function(path) {
+			var sections = path.split('/');
+			for (var i = 0; i < sections.length; i++) {
+				if (sections[i] === '..') {
+					return false;
+				}
+			}
+
+			return path.toLowerCase().indexOf(decodeURI('%0a')) === -1 &&
+				path.toLowerCase().indexOf(decodeURI('%00')) === -1;
+		},
+
+		/**
 		 * Populates the view if there are images or albums to show
 		 *
 		 * @param {string} albumPath
 		 * @param {string|undefined} errorMessage
 		 */
 		init: function (albumPath, errorMessage) {
-			// Remove all null-bytes from the path
-			albumPath = albumPath.replace(/\0/g, '');
+			// Set path to an empty value if not a valid one
+			if(!this._isValidPath(albumPath)) {
+				albumPath = '';
+			}
 
 			// Only do it when the app is initialised
 			if (this.requestId === -1) {


### PR DESCRIPTION
Otherwise somebody could let somebody open "http://10.211.55.7/stable9/index.php/apps/gallery/#Please contact support@foo.com%00" and thus make the person believe that this is part of a valid error message. As an hardening measure, we should not display anything rather in this case.


@oparoz Thoughts? I'd appreciate a review and backport if you don't consider this too ugly :-)