### PR TITLE
Hide icon-loading-dark after loading the image

### DIFF
--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -97,6 +97,7 @@
 			this.container.show();
 			this.container.css('background-position', 'center');
 			this._hideImage();
+			this.container.find('.icon-loading-dark').show();
 			var currentImageId = index;
 			return this.loadImage(this.images[index]).then(function (img) {
 				this.container.css('background-position', '-10000px 0');
@@ -125,6 +126,7 @@
 
 					this._setUrl(image.path);
 					this.controls.show(currentImageId);
+					this.container.find('.icon-loading-dark').hide();
 				}
 			}.bind(this), function () {
 				// Don't do anything if the user has moved along while we were loading as it would


### PR DESCRIPTION
Fixes: #160

Licence: MIT or AGPL
### Description

Hide icon-loading-dark after loading the image and displaying it back when the image is loading.
### Tested on
- [x] Ubuntu 14.04/Chrome
### Reviewers

@oparoz
