### PR TITLE
Make use of the IPreview so we use shared previews

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -53,6 +53,7 @@ use OCA\Gallery\Utility\EventSource;
 
 use OCA\OcUtility\AppInfo\Application as OcUtility;
 use OCA\OcUtility\Service\SmarterLogger as SmarterLogger;
+use OCP\IPreview;
 
 /**
  * Class Application
@@ -248,9 +249,7 @@ class Application extends App {
 		$container->registerService(
 			'CustomPreviewManager', function (IContainer $c) {
 			return new Preview(
-				$c->query('OCP\IConfig'),
-				$c->query('OCP\IPreview'),
-				$c->query('Logger')
+				$c->query(IPreview::class)
 			);
 		}
 		);

--- a/preview/preview.php
+++ b/preview/preview.php
@@ -12,65 +12,32 @@
 
 namespace OCA\Gallery\Preview;
 
-use OCP\IConfig;
-use OCP\Image;
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use OCP\Image;
 use OCP\IPreview;
-use OCP\ILogger;
 
 /**
  * Generates previews
- *
- * @todo On OC9, replace \OC\Preview with IPreview if methods we need have been added
  *
  * @package OCA\Gallery\Preview
  */
 class Preview {
 
 	/**
-	 * @var string
-	 */
-	private $dataDir;
-	/**
-	 * @var mixed
+	 * @var IPreview
 	 */
 	private $previewManager;
-	/**
-	 * @var ILogger
-	 */
-	private $logger;
-	/**
-	 * @var string
-	 */
-	private $userId;
-	/**
-	 * @var \OC\Preview
-	 */
-	private $preview;
-	/**
-	 * @var File
-	 */
-	private $file;
-	/**
-	 * @var int[]
-	 */
-	private $dims;
 
 	/**
 	 * Constructor
 	 *
-	 * @param IConfig $config
 	 * @param IPreview $previewManager
-	 * @param ILogger $logger
 	 */
 	public function __construct(
-		IConfig $config,
-		IPreview $previewManager,
-		ILogger $logger
+		IPreview $previewManager
 	) {
-		$this->dataDir = $config->getSystemValue('datadirectory');
 		$this->previewManager = $previewManager;
-		$this->logger = $logger;
 	}
 
 	/**
@@ -85,75 +52,24 @@ class Preview {
 	}
 
 	/**
-	 * Initialises the view which will be used to access files and generate previews
-	 *
-	 * @fixme Private API, but can't use the PreviewManager yet as it's incomplete
-	 *
-	 * @param string $userId
 	 * @param File $file
-	 * @param string $imagePathFromFolder
-	 */
-	public function setupView($userId, $file, $imagePathFromFolder) {
-		$this->userId = $userId;
-		$this->file = $file;
-		$imagePathFromFolder = ltrim($imagePathFromFolder, '/');
-		$this->preview = new \OC\Preview($userId, 'files', $imagePathFromFolder);
-	}
-
-	/**
-	 * Returns a preview based on OC's preview class and our custom methods
-	 *
-	 * We check that the preview returned by the Preview class can be used by
-	 * the browser. If not, we send "false" to the controller
-	 *
-	 * @fixme setKeepAspect is missing from public interface.
-	 *     https://github.com/owncloud/core/issues/12772
-	 *
-	 * @param int $maxWidth
-	 * @param int $maxHeight
+	 * @param int $maxX
+	 * @param int $maxY
 	 * @param bool $keepAspect
-	 *
-	 * @return array<string,string|\OC_Image>|false
+	 * @return false|array<string,string|\OC_Image>
 	 */
-	public function preparePreview($maxWidth, $maxHeight, $keepAspect) {
-		$this->dims = [$maxWidth, $maxHeight];
-
-		$previewData = $this->getPreviewFromCore($keepAspect);
-
-		if ($previewData && $previewData->valid()) {
-			$preview = [
-				'preview'  => $previewData,
-				'mimetype' => $previewData->mimeType()
-			];
-		} else {
-			$preview = false;
+	public function getPreview(File $file, $maxX, $maxY, $keepAspect) {
+		try {
+			$preview = $this->previewManager->getPreview($file, $maxX, $maxY, !$keepAspect);
+		} catch (NotFoundException $e) {
+			return false;
 		}
 
-		return $preview;
-	}
-
-	/**
-	 * Asks core for a preview based on our criteria
-	 *
-	 * @todo Need to read scaling setting from settings
-	 *
-	 * @param bool $keepAspect
-	 *
-	 * @return \OC_Image
-	 */
-	private function getPreviewFromCore($keepAspect) {
-		list($maxX, $maxY) = $this->dims;
-
-		$this->preview->setMaxX($maxX);
-		$this->preview->setMaxY($maxY);
-		$this->preview->setScalingUp(false);
-		$this->preview->setKeepAspect($keepAspect);
-
-		//$this->logger->debug("[PreviewService] preview {preview}", ['preview' => $this->preview]);
-
-		$previewData = $this->preview->getPreview();
-
-		return $previewData;
+		$img = new Image($preview->getContent());
+		return [
+			'preview'  => $img,
+			'mimetype' => $img->mimeType()
+		];
 	}
 
 }

--- a/service/previewservice.php
+++ b/service/previewservice.php
@@ -102,10 +102,7 @@ class PreviewService extends Service {
 		$file, $maxX = 0, $maxY = 0, $keepAspect = true, $base64Encode = false
 	) {
 		try {
-			$userId = $this->environment->getUserId();
-			$imagePathFromFolder = $this->environment->getPathFromUserFolder($file);
-			$this->previewManager->setupView($userId, $file, $imagePathFromFolder);
-			$preview = $this->previewManager->preparePreview($maxX, $maxY, $keepAspect);
+			$preview = $this->previewManager->getPreview($file, $maxX, $maxY, $keepAspect);
 			if ($preview && $base64Encode) {
 				$preview['preview'] = $this->encode($preview['preview']);
 			}

--- a/tests/unit/preview/PreviewTest.php
+++ b/tests/unit/preview/PreviewTest.php
@@ -50,11 +50,7 @@ class PreviewTest extends \Test\GalleryUnitTest {
 		$this->logger = $this->getMockBuilder('\OCP\ILogger')
 							 ->disableOriginalConstructor()
 							 ->getMock();
-		$this->previewManager = new Preview(
-			$this->config,
-			$this->corePreviewManager,
-			$this->logger
-		);
+		$this->previewManager = new Preview($this->corePreviewManager);
 	}
 
 	/**

--- a/tests/unit/preview/PreviewTest.php
+++ b/tests/unit/preview/PreviewTest.php
@@ -12,12 +12,8 @@
 
 namespace OCA\Gallery\Preview;
 
-use OCP\IConfig;
+use OCP\Files\File;
 use OCP\IPreview;
-use OCP\ILogger;
-
-use OCA\Gallery\AppInfo\Application;
-
 
 /**
  * Class PreviewTest
@@ -26,12 +22,8 @@ use OCA\Gallery\AppInfo\Application;
  */
 class PreviewTest extends \Test\GalleryUnitTest {
 
-	/** @var IConfig */
-	private $config;
-	/** @var IPreview */
+	/** @var IPreview|\PHPUnit_Framework_MockObject_MockObject */
 	private $corePreviewManager;
-	/** @var ILogger */
-	protected $logger;
 	/** @var Preview */
 	private $previewManager;
 
@@ -41,15 +33,9 @@ class PreviewTest extends \Test\GalleryUnitTest {
 	public function setUp() {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
-							 ->disableOriginalConstructor()
-							 ->getMock();
-		$this->corePreviewManager = $this->getMockBuilder('\OCP\IPreview')
+		$this->corePreviewManager = $this->getMockBuilder(IPreview::class)
 										 ->disableOriginalConstructor()
 										 ->getMock();
-		$this->logger = $this->getMockBuilder('\OCP\ILogger')
-							 ->disableOriginalConstructor()
-							 ->getMock();
 		$this->previewManager = new Preview($this->corePreviewManager);
 	}
 
@@ -59,50 +45,14 @@ class PreviewTest extends \Test\GalleryUnitTest {
 	public function testGetPreviewFromCoreWithBrokenSystem() {
 		$keepAspect = true; // Doesn't matter
 		$exception = new \Exception('Encryption ate your file');
-		$preview = $this->mockGetPreviewWithBrokenSetup($exception);
-		self::invokePrivate($this->previewManager, 'preview', [$preview]);
+		$this->corePreviewManager->method('getPreview')
+			->willThrowException($exception);
 
-		self::invokePrivate($this->previewManager, 'getPreviewFromCore', [$keepAspect]);
+		$this->previewManager->getPreview(
+			$this->createMock(File::class),
+			42,
+			42,
+			$keepAspect
+		);
 	}
-
-	/**
-	 * @param $fileId
-	 * @param $width
-	 * @param $height
-	 *
-	 * @return object|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	private function mockGetPreview($fileId, $width, $height) {
-		$image = new \OC_Image(file_get_contents(\OC::$SERVERROOT . '/tests/data/testimage.jpg'));
-		$image->preciseResize($width, $height);
-
-		$preview = $this->getMockBuilder('\OC\Preview')
-						->disableOriginalConstructor()
-						->getMock();
-		$preview->method('getPreview')
-				->willReturn($image);
-		$preview->method('isCached')
-				->willReturn($fileId);
-
-		return $preview;
-	}
-
-	private function mockGetPreviewWithBrokenSetup($exception) {
-		$preview = $this->getMockBuilder('\OC\Preview')
-						->disableOriginalConstructor()
-						->getMock();
-		$preview->method('setMaxX')
-				->willReturn(null);
-		$preview->method('setMaxY')
-				->willReturn(null);
-		$preview->method('setScalingUp')
-				->willReturn(null);
-		$preview->method('setKeepAspect')
-				->willReturn(null);
-		$preview->method('getPreview')
-				->willThrowException($exception);
-
-		return $preview;
-	}
-
 }

--- a/tests/unit/service/PreviewServiceTest.php
+++ b/tests/unit/service/PreviewServiceTest.php
@@ -27,7 +27,7 @@ class PreviewServiceTest extends \Test\GalleryUnitTest {
 
 	/** @var PreviewService */
 	protected $service;
-	/** @var Preview */
+	/** @var Preview|\PHPUnit_Framework_MockObject_MockObject */
 	protected $previewManager;
 
 	/**
@@ -133,7 +133,9 @@ class PreviewServiceTest extends \Test\GalleryUnitTest {
 	public function testCreatePreviewWithBrokenSystem() {
 		/** @type File $file */
 		$file = $this->mockJpgFile(12345);
-		$this->mockGetUserIdFails();
+
+		$this->previewManager->method('getPreview')
+			->willThrowException(new \Exception('BOOM'));
 
 		$this->service->createPreview(
 			$file, $maxX = 0, $maxY = 0, $keepAspect = true, $base64Encode = false


### PR DESCRIPTION
* Rip out private calls to \OC\Preview
* Use \OCP\IPreview so we use the shared previews by default
* Leave the wrapper for now

Fixes: https://github.com/nextcloud/gallery/issues/185

TODO:
- [x] Fix tests
