### PR TITLE
Popover to css guidelines

### DIFF
--- a/css/upload.css
+++ b/css/upload.css
@@ -41,7 +41,7 @@
 	top: 100%;
 	margin-top: 4px;
 	min-width: 100px;
-	margin-left: 7px;
+	margin-left: 3px;
 	z-index: 1001;
 }
 

--- a/css/upload.css
+++ b/css/upload.css
@@ -37,9 +37,11 @@
 }
 
 .newFileMenu {
-	width: 140px;
-	margin-left: -56px;
-	margin-top: 25px;
+	font-weight: 300;
+	top: 100%;
+	margin-top: 4px;
+	min-width: 100px;
+	margin-left: 7px;
 	z-index: 1001;
 }
 
@@ -51,31 +53,8 @@
 	box-shadow: 0 0 6px #f8b9b7;
 }
 
-.newFileMenu .menuitem {
-	white-space: nowrap;
-	overflow: hidden;
-}
 .newFileMenu.popovermenu .menuitem .icon {
 	margin-bottom: -2px;
-}
-.newFileMenu.popovermenu a.menuitem,
-.newFileMenu.popovermenu label.menuitem,
-.newFileMenu.popovermenu .menuitem {
-	padding: 0;
-	margin: 0;
-}
-
-.newFileMenu.popovermenu a.menuitem.active {
-	opacity: 1;
-}
-
-.newFileMenu.bubble:after {
-	left: 75px;
-	right: auto;
-}
-.newFileMenu.bubble:before {
-	left: 75px;
-	right: auto;
 }
 
 .newFileMenu .filenameform {
@@ -83,7 +62,7 @@
 }
 
 .newFileMenu .filenameform input {
-	width: 100px;
+	margin: 2px 0;
 }
 
 #fileList .popovermenu .action {

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -2,7 +2,7 @@
 (function ($, _, OC, t, Gallery) {
 	"use strict";
 
-	var TEMPLATE_ADDBUTTON = '<a href="#" class="button new"><img src="{{iconUrl}}" alt="{{addText}}"></img></a>';
+	var TEMPLATE_ADDBUTTON = '<a href="#" class="button new"><span class="icon icon-add"></span><span class="hidden-visually">New</span></a>';
 
 	/**
 	 * Builds and updates the Gallery view

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -569,7 +569,7 @@
 			}
 			if (!this._newFileMenu) {
 				this._newFileMenu = new Gallery.NewFileMenu();
-				$('body').append(this._newFileMenu.$el);
+				$('.actions').append(this._newFileMenu.$el);
 			}
 			this._newFileMenu.showAt($target);
 

--- a/js/vendor/owncloud/newfilemenu.js
+++ b/js/vendor/owncloud/newfilemenu.js
@@ -31,7 +31,8 @@
 	 */
 	var NewFileMenu = OC.Backbone.View.extend({
 		tagName: 'div',
-		className: 'newFileMenu popovermenu bubble hidden open menu',
+		// Menu is opened by default because it's rendered on "add-button" click
+		className: 'newFileMenu popovermenu bubble menu open menu-left',
 
 		events: {
 			'click .menuitem': '_onClickAction'
@@ -126,13 +127,6 @@
 		 */
 		showAt: function ($target) {
 			this.render();
-			var targetOffset = $target.offset();
-			this.$el.css({
-				left: targetOffset.left,
-				top: targetOffset.top + $target.height()
-			});
-			this.$el.removeClass('hidden');
-
 			OC.showMenu(null, this.$el);
 		}
 	});


### PR DESCRIPTION

![capture d ecran_2017-02-12_05-42-18](https://cloud.githubusercontent.com/assets/14975046/22859712/0916932e-f0e6-11e6-85c0-d77cd0d5f137.png)


Refs: nextcloud/server#3118


Ps: non related to this pr, but the other icons are still using img. It could be great if you could use span with icon inside instead (see buttons in files for example)