### PR TITLE
Push a state in the history on direct image link

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -37,6 +37,10 @@ $(document).ready(function () {
 					))
 					.then(function () {
 						Gallery.getFiles(currentLocation).then(function () {
+							if (history && history.pushState) {
+								// Going back in the history will show the photowall
+								history.pushState(null, '', '#' + currentLocation);
+							}
 							window.onhashchange();
 						});
 					});


### PR DESCRIPTION

Licence: MIT or AGPL

### Description

The main goal is to fix a bug when the user goes directly to an image (http://cloud.pfad.fr/index.php/apps/gallery/s/08HPBae4d4OX62p#navbit-home.png for instance), clicking the "X" at the top right redirects to the previous page (or does nothing if it opened a new tab).

### Features

* With this fix, clicking the "X" goes back to the gallery.

### Caveats

* clicking the "Back" button of the browser also goes to the gallery (instead of the previous page), but this can been also seen as a feature

## Tests

*Is there any test set up for JS?*
 
### Tested on

- [x] ArchLinux/Chromium

### Check list

- [x] Code is properly documented
- [x] Code is properly formatted
- [ ] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required

### Reviewers

@oparoz maybe?