### PR TITLE
Fix Gallery share button not showing with Adblock

### DIFF
--- a/css/gallerybutton.css
+++ b/css/gallerybutton.css
@@ -53,7 +53,7 @@
 	margin-left: -1px;
 }
 
-#share-button img,
+#shared-button img,
 .button.left-switch-button img,
 .button.right-switch-button img {
 	vertical-align: -3px;

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -370,7 +370,7 @@
 			this.element.on("contextmenu", function(e) { e.preventDefault(); });
 			$('#filelist-button').click(Gallery.switchToFilesView);
 			$('#download').click(Gallery.download);
-			$('#share-button').click(Gallery.share);
+			$('#shared-button').click(Gallery.share);
 			Gallery.infoBox = new Gallery.InfoBox();
 			$('#album-info-button').click(Gallery.showInfo);
 			$('#sort-name-button').click(Gallery.sorter);
@@ -398,7 +398,7 @@
 			var availableWidth = $(window).width() - Gallery.buttonsWidth;
 			this.breadcrumb.init(albumPath, availableWidth);
 			var album = Gallery.albumMap[albumPath];
-			
+
 			var sum = album.images.length + album.subAlbums.length;
 			//If sum of the number of images and subalbums exceeds 1 then show the buttons.
 			if(sum > 1)
@@ -431,7 +431,7 @@
 		 */
 		_hideButtons: function (uploadAllowed) {
 			$('#album-info-button').hide();
-			$('#share-button').hide();
+			$('#shared-button').hide();
 			$('#sort-name-button').hide();
 			$('#sort-date-button').hide();
 			$('#save-button').hide();
@@ -449,7 +449,7 @@
 		 * @private
 		 */
 		_shareButtonSetup: function (albumPath) {
-			var shareButton = $('#share-button');
+			var shareButton = $('#shared-button');
 			if (albumPath === '' || Gallery.token) {
 				shareButton.hide();
 			} else {
@@ -540,7 +540,7 @@
 					});
 			}
 		},
-		
+
 		/**
 		 * If no url is entered then do not show the error box.
 		 *
@@ -554,7 +554,7 @@
  				}
 			});
 		},
-		
+
 		/**
 		 * Creates the [+] button allowing users who can't drag and drop to upload files
 		 *

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -74,9 +74,9 @@ style(
 	<div id="file_action_panel"></div>
 	<span class="right">
 		<!-- sharing button -->
-		<div id="share-button" class="button">
+		<div id="shared-button" class="button">
 			<img class="svg" src="<?php print_unescaped(
-				image_path('core', 'actions/share.svg')
+				image_path('core', 'actions/shared.svg')
 			); ?>" alt="<?php p($l->t("Share")); ?>"/>
 		</div>
 		<a class="share" data-item-type="folder" data-item=""


### PR DESCRIPTION
Please review @oparoz @MariusBluem @MorrisJobke 

This is the equivalent of https://github.com/nextcloud/server/pull/4337 for the Gallery, simply renaming »share-button« to share_d_-button so that Adblock doesn’t hide it and mess it up.