### PR TITLE
No need to construct the image in memory

### DIFF
--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -87,9 +87,15 @@ trait Preview {
 			);
 		if ($preview === null) {
 			$preview = $this->prepareEmptyThumbnail($file, $status);
+			return [$preview, $status];
 		}
 
-		return [$preview, $status];
+		$result = [
+			'preview' => $base64Encode ? base64_encode($preview->getContent()) : $preview->getContent(),
+			'mimetype' => $file->getMimeType()
+		];
+
+		return [$result, $status];
 	}
 
 	/**
@@ -156,7 +162,7 @@ trait Preview {
 	 * @param bool $keepAspect
 	 * @param bool $base64Encode
 	 *
-	 * @return array<\OC_Image|string, int>
+	 * @return array<File|ISimpleFile, int>
 	 */
 	private function getPreviewData(
 		$file, $animatedPreview, $width, $height, $keepAspect, $base64Encode

--- a/lib/Service/DownloadService.php
+++ b/lib/Service/DownloadService.php
@@ -28,26 +28,16 @@ class DownloadService extends Service {
 	 * Downloads the requested file
 	 *
 	 * @param File $file
-	 * @param bool $base64Encode
 	 *
-	 * @return array|false
+	 * @return File
 	 * @throws NotFoundServiceException
 	 */
-	public function downloadFile($file, $base64Encode = false) {
+	public function downloadFile($file) {
 		try {
 			$this->logger->debug(
 				"[DownloadService] File to Download: {name}", ['name' => $file->getName()]
 			);
-			$download = [
-				'preview'  => $file->getContent(),
-				'mimetype' => $file->getMimeType()
-			];
-
-			if ($base64Encode) {
-				$download['preview'] = $this->encode($download['preview']);
-			}
-
-			return $download;
+			return $file;
 		} catch (\Exception $exception) {
 			throw new NotFoundServiceException('There was a problem accessing the file');
 		}

--- a/lib/Service/PreviewService.php
+++ b/lib/Service/PreviewService.php
@@ -13,6 +13,7 @@
 namespace OCA\Gallery\Service;
 
 use OCP\Files\File;
+use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Image;
 use OCP\IPreview;
 use OCP\ILogger;
@@ -94,26 +95,14 @@ class PreviewService extends Service {
 	 * @param int $maxX asked width for the preview
 	 * @param int $maxY asked height for the preview
 	 * @param bool $keepAspect
-	 * @param bool $base64Encode
 	 *
-	 * @return string|\OC_Image|string|false preview data
+	 * @return ISimpleFile preview
 	 * @throws InternalServerErrorServiceException
 	 */
-	public function createPreview(
-		$file, $maxX = 0, $maxY = 0, $keepAspect = true, $base64Encode = false
+	public function createPreview(File $file, $maxX = 0, $maxY = 0, $keepAspect = true
 	) {
 		try {
-			$preview = $this->previewManager->getPreview($file, $maxX, $maxY, !$keepAspect);
-			$img = new Image($preview->getContent());
-			$mimeType = $img->mimeType();
-			if ($img && $base64Encode) {
-				$img = $this->encode($img);
-			}
-
-			return [
-				'preview'  => $img,
-				'mimetype' => $mimeType
-			];
+			return $this->previewManager->getPreview($file, $maxX, $maxY, !$keepAspect);
 		} catch (\Exception $exception) {
 			throw new InternalServerErrorServiceException('Preview generation has failed');
 		}


### PR DESCRIPTION
Not constructing the image in memory saves valuable resources

* Pass around File or ISimpleFile objects
* Use the FileDisplayResponse so we have all the fancy caching
* fixes #242 

TODO:
- [ ] Fix tests