### PR TITLE
create "file app" public share links if the slideshow is opened from …

### DIFF
--- a/js/galleryfileaction.js
+++ b/js/galleryfileaction.js
@@ -227,4 +227,9 @@ $(document).ready(function () {
 		window.galleryFileAction.buildFeaturesList(config.features);
 		window.galleryFileAction.register(config.mediatypes);
 	});
+
+	// create public share links as from the files app
+	if (!Gallery.appName) {
+		Gallery.appName = 'files';
+	}
 });

--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -580,8 +580,13 @@
 			$linkCheckbox.attr('data-id', id);
 			var $linkText = $('#linkText');
 
-			var link = parent.location.protocol + '//' + location.host +
-				OC.generateUrl('/apps/gallery/s/') + token;
+			if (Gallery.appName === 'files') {
+				var link = parent.location.protocol + '//' + location.host +
+					OC.generateUrl('/s/') + token;
+			} else {
+				var link = parent.location.protocol + '//' + location.host +
+					OC.generateUrl('/apps/gallery/s/') + token;
+			}
 
 			$linkText.val(link);
 			$linkText.slideDown(OC.menuSpeed);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/gallery/issues/268

We also need to look at the public share links that are shown in the slideshow from the gallery app, currently if you use those links it will always download the image with no method of viewing it in browser.