### PR TITLE
Gallery.Share might be undefined, slideshow breaks without condition

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -350,7 +350,9 @@
 		 * @private
 		 */
 		_next: function () {
-			Gallery.Share.hideDropDown();
+			if(!_.isUndefined(Gallery.Share)) {
+				Gallery.Share.hideDropDown();
+			}
 			this._setName('');
 			this.slideshow.hideErrorNotification();
 			this.zoomablePreview.reset();
@@ -369,7 +371,9 @@
 		 * @private
 		 */
 		_previous: function () {
-			Gallery.Share.hideDropDown();
+			if(!_.isUndefined(Gallery.Share)) {
+				Gallery.Share.hideDropDown();
+			}
 			this._setName('');
 			this.slideshow.hideErrorNotification();
 			this.zoomablePreview.reset();


### PR DESCRIPTION
Fixes: Slideshow does not continue

Licence: AGPL

### Description

On my production system, it was figured out, that the slideshow does not continue. A JS error was shown: Gallery.Share is undefined. Stable12 is affected.

I am not much deep into this code here to know why, but embedding the responsible code line into an if condition fixes it for me. Unfortunately, I could not reproduce it on my dev environment, only production :( As of now, no idea if there is a better fix possible.

### Tested on

- [X] Linux/Firefox

