### PR TITLE
Fix logged error if file ID is not available

### DIFF
--- a/lib/Environment/Environment.php
+++ b/lib/Environment/Environment.php
@@ -357,7 +357,7 @@ class Environment {
 	private function getResourceFromFolderAndId($folder, $resourceId) {
 		$resourcesArray = $folder->getById($resourceId);
 
-		if ($resourcesArray[0] === null) {
+		if (!isset($resourcesArray[0])) {
 			throw new NotFoundEnvException('Could not locate node linked to ID: ' . $resourceId);
 		}
 


### PR DESCRIPTION
fixes errors like this:

```
"url":"/apps/gallery/preview/426429?width=3400&height=3400&c=594c37c83d999&requesttoken=VY8nKK5eeu3W6uVKtFvD+YSnXVfoXdas+mQvmFgXZGU=:YsZFTOgXCoOk3td/wQiVivTKFTOpC5fKmSNswDRQNFE=",
"message":"Undefined offset: 0 at /var/www/nextcloud/apps/gallery/lib/Environment/Environment.php#360",
```

and 

```
"url":"/apps/gallery/preview/426429?width=3400&height=3400&c=594c37c83d999&requesttoken=VY8nKK5eeu3W6uVKtFvD+YSnXVfoXdas+mQvmFgXZGU=:YsZFTOgXCoOk3td/wQiVivTKFTOpC5fKmSNswDRQNFE=",
"message":"ExceptionCould not locate node linked to ID: 426429",
```

to only log the last error and not both.

