### PR TITLE
Fix download icon and logo on gallery share view

### DIFF
--- a/templates/public.php
+++ b/templates/public.php
@@ -30,7 +30,7 @@ style(
 	<div id="header">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
 		   title="" id="nextcloud">
-			<div class="logo-icon svg">
+			<div class="logo logo-icon svg">
 			</div>
 		</a>
 
@@ -61,11 +61,8 @@ style(
 								</span>
 				<?php } ?>
 				<a id="download" class="button">
-					<img class="svg" src="<?php print_unescaped(
-						image_path('core', 'actions/download.svg')
-					); ?>" alt=""/>
-						<span id="download-text"><?php p($l->t('Download')) ?>
-						</span>
+					<span class="icon-download"></span>
+					<span id="download-text"><?php p($l->t('Download')) ?></span>
 				</a>
 			</span>
 		</div>


### PR DESCRIPTION
Fixes: #269 

### Description
Also check https://github.com/nextcloud/server/pull/5920

By the way, since this might be backported, logo fix only affects bug introduced in Nextcloud v13, but backporting this PR will not introduce a regression.

### Screenshots or screencasts
Before:
![image](https://user-images.githubusercontent.com/4129927/28718310-a238e416-73a5-11e7-9d93-39c0a5687ef7.png)

After:
![image](https://user-images.githubusercontent.com/4129927/28718292-907c4524-73a5-11e7-82ae-e9fcb32ce57b.png)

### Tested on

- [x] Linux/Firefox