### PR TITLE
height fix for IE11

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -10,6 +10,11 @@ body {
 	overflow: hidden;
 }
 
+/* height fix for ie11 */
+html.ie #content {
+	height: auto;
+}
+
 /* within #save */
 #save .save-form {
 	position: relative;


### PR DESCRIPTION
in shared link view the gallery is not scrollable in ie11

Licence: MIT or AGPL

- [x] Windows/Internet Explorer 11
- [x] Windows/Edge
- [x] Android 6.1/Chrome

### Check list

- [x] Code is properly documented
- [x] Code is properly formatted
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
