### PR TITLE
Fixed too wide selector for the popovermenu

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -1349,7 +1349,7 @@ $(document).ready(function () {
 		}
 	});
 
-	$(document).on('click', '.icon-more', function(event) {
+	$(document).on('click', '#dropdown .icon-more', function(event) {
 		event.preventDefault();
 		event.stopPropagation();
 


### PR DESCRIPTION
This was interfering with some other menus on the nextcloud server

@nextcloud/javascript @nextcloud/designers 
