### PR TITLE
Ignore unavailable storage instead of breaking for all

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -15,6 +15,7 @@ namespace OCA\Gallery\Service;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Node;
+use OCP\Files\StorageNotAvailableException;
 
 /**
  * Contains various methods to retrieve information from the filesystem
@@ -142,8 +143,12 @@ abstract class FilesService extends Service {
 	protected function getAllowedSubFolder($node, $nodeType) {
 		if ($nodeType === 'dir') {
 			/** @var Folder $node */
-			if (!$node->nodeExists($this->ignoreAlbum)) {
-				return [$node];
+			try {
+				if (!$node->nodeExists($this->ignoreAlbum)) {
+					return [$node];
+				}
+			} catch (StorageNotAvailableException $e) {
+				return [];
 			}
 		}
 


### PR DESCRIPTION
Fixes: When e.g. a share folder is not available OCP\StorageNotAvailableException is throw, but was never catched. Rendering Gallery broken for everything.

Needs backporting to 12 at least (didn't test 11).

Licence:  AGPL

