### PR TITLE
Make acceptance tests run and pass on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,7 @@ after_success:
 
 after_failure:
   - cat tests/_output/phpbuiltinserver.errors.txt
+  - cat tests/_output/phpbuiltinserver.access_log.txt
   - bash build/after_failure.sh
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - graphviz
       - gdb
       - dbus-x11
+  firefox: "latest"
 env:
   global:
     - CORE_BRANCH=master
@@ -46,8 +47,12 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
-  - sh -c "if [ ! -e ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar ]; then wget -O ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar https://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.0.jar; fi;"
-  - java -jar ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar -port 4444 >/dev/null 2>&1 & # WARNING - Takes a long time to start up. Keep here
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
+  - sh -c "wget -O ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar https://selenium-release.storage.googleapis.com/3.7/selenium-server-standalone-3.7.1.jar;"
+  - java -jar ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar -port 4444 -enablePassThrough false >/dev/null 2>&1 & # WARNING - Takes a long time to start up. Keep here
 
   # Ghostdriver does not work on Travis - Download the latest PhantomJS
   #- mkdir travis-phantomjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     packages:
       - graphviz
       - gdb
+      - dbus-x11
 env:
   global:
     - CORE_BRANCH=master

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require-dev": {
     "guzzlehttp/guzzle": "^6.2",
     "phpunit/phpunit": "^5.7|^6.0",
-    "codeception/codeception": "2.2.*",
+    "codeception/codeception": "2.3.*",
     "codeception/phpbuiltinserver": "*",
     "composer-plugin-api": "^1.0",
     "codeception/c3": "2.*",


### PR DESCRIPTION
Fixes: #329

Licence: AGPL

### Description

Make acceptance tests run and pass on Travis by updating the whole toolchain.

### Features

* Add missing dbus-x11 package needed for Firefox to run (package has been removed in recent Travis images by default)
* Update selenium to v3, alongside with geckodriver (only available interface between Webdriver and Firefox in recent Firefox versions)
* Add access_log in case of failure, quite useful in a lot of cases
* Update Codeception to 2.3 (it appears that it is not related at all to our issue but after testing it does not seem to do any harm)

### Caveats

* Travis has problems with intermitent failures with acceptance tests regarding login (which is still better than no test at all but far from ideal) that seem impossible to reproduce with local phantomjs.