### PR TITLE
Travis: remove dbus which seems no longer needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     packages:
       - graphviz
       - gdb
-      - dbus-x11
   firefox: "latest"
 env:
   global:


### PR DESCRIPTION
dbus fails to install, removing it does not cause havok probably because of new version of Firefox used in previous PR #330.

Fixes: #329 (again)
