### PR TITLE
[stable12] Fix the root folder detection for mounts points to '/'

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -166,7 +166,7 @@ abstract class FilesService extends Service {
 	protected function isRootFolder($folder, $level) {
 		$isRootFolder = false;
 		$rootFolder = $this->environment->getVirtualRootFolder();
-		if ($folder->getPath() === $rootFolder->getPath()) {
+		if (rtrim($folder->getPath(), '/') === rtrim($rootFolder->getPath(), '/')) {
 			$isRootFolder = true;
 		}
 		$virtualRootFolder = $this->environment->getPathFromVirtualRoot($folder);


### PR DESCRIPTION
This fixes an endless recursion for the case, that an external storage is mounted to "/". Then the `isRootFolder` method never evaluated to true, because a trailing slash was the actual diff between the current path and the root folders path.


Backport of #339 