### PR TITLE
Fix chess board background for transparent images in slide show

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -26,6 +26,7 @@
 
 #slideshow img:hover {
 	background: black url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAMFBMVEX/AAD/AP8AAP8A//8A/wD//wB/AAB/AH8AAH8Af38AfwCCfwAAAAAZGRkzMzNMTEy64p6SAAAAF0lEQVQI12P4DwRngICBQgaIAHEoZAAASHBywR1kvCwAAAAASUVORK5CYII=) repeat;
+	background-size: 16px !important;
 }
 
 #slideshow > input {


### PR DESCRIPTION
Was overwritten by attributes that where applied directly on the dom node.

Fixes https://github.com/nextcloud/server/issues/7486