### PR TITLE
Fix three dots menu visible in share dropdown

### DIFF
--- a/css/share.css
+++ b/css/share.css
@@ -129,7 +129,7 @@ a.unshare {
 	margin-right: 0;
 }
 
-#linkText,#linkPass,#expiration {
+#linkText,#linkTextMore,#linkPass,#expiration {
 	display:none;
 }
 

--- a/css/share.css
+++ b/css/share.css
@@ -129,7 +129,9 @@ a.unshare {
 	margin-right: 0;
 }
 
-#linkText,#linkTextMore,#linkPass,#expiration {
+#linkText,#linkTextMore,#linkPass,#expiration,
+/* Override "display: inline-block" rule for controls in server */
+#controls #linkText,#controls #linkTextMore {
 	display:none;
 }
 

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -211,9 +211,6 @@
 					.data('item-source', currentAlbum.fileId)
 					.data('possible-permissions', currentAlbum.permissions)
 					.click();
-				if (!$('#linkCheckbox').is(':checked')) {
-					$('#linkText').hide();
-				}
 			}
 		},
 

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -233,9 +233,6 @@
 					.data('item-source', image.file)
 					.data('possible-permissions', image.permissions)
 					.click();
-				if (!$('#linkCheckbox').is(':checked')) {
-					$('#linkText').hide();
-				}
 			}
 		},
 


### PR DESCRIPTION
Fixes #345

Although #345 refers to the share dropdown in the slideshow the issue happened too in the share dropdown for folders in the gallery; this pull request fixes both.
