### PR TITLE
Fix date picker not visible in slideshow sharing dialog

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -200,3 +200,10 @@
 	/** above slideshow buttons */
 	z-index: 100001;
 }
+
+#slideshow ~ .ui-datepicker {
+	/* Larger than the slideshow share dropdown z-index, and important
+	   to override both the important z-index from the server and the
+	   value set in the element by jQuery UI Datepicker Widget */
+	z-index: 100010 !important;
+}


### PR DESCRIPTION
Fixes #313 

The jQuery UI Datepicker Widget automatically [sets the `z-index` of the date picker element to the `z-index+1` of the element it is called on](https://github.com/jquery/jquery-ui/blob/1.10.0/ui/jquery.ui.datepicker.js#L747). However [the server sets the `z-index` of the date picker using `!important` in its CSS files](https://github.com/nextcloud/server/blob/5591ea6e8bef0f87d1ebc915fd43a9acd7719890/core/css/share.scss#L204), so it overrides the value set directly on the element. As the `z-index` of the slideshow is `100000`, the `z-index` of the date picker element set in the server is `1111`, and the date picker element is a sibling of the slideshow element the date picker appears behind it and thus it is not visible.

But, why is the `z-index` explicitly set in the server CSS files if the widget automatically sets it? Because the automatic calculation of the z-index is flawed. [The `z-index` of the element is got from the first ancestor (or itself) that has an absolute, relative or fixed position](https://github.com/jquery/jquery-ui/blob/1.10.0/ui/jquery.ui.core.js#L85-L112). However, the relevant `z-index` for the date picker element is the one from the ancestor element that is also a sibling of the date picker element, so depending on the DOM structure and CSS rules the automatic `z-index` could work or not, and thus an explicit `z-index` is needed instead.

Due to all this the problem has to be solved by overriding both the `z-index` set by the server CSS files and the `z-index` automatically set on the `style` attribute of the element, which fortunately can be done by setting the `z-index` with `!important` and a more specific selector than the one used in the server CSS file.

  