### PR TITLE
Hide the share drop down when closing the slideshow

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -396,6 +396,9 @@
 		 * @private
 		 */
 		_exit: function () {
+			if (Gallery.Share){
+				Gallery.Share.hideDropDown();
+			}
 
 			// Only modern browsers can manipulate history
 			if (history && history.replaceState) {


### PR DESCRIPTION
The share drop down is shared between the gallery and the slideshow. When the share button of the gallery is clicked the share drop down is shown [only if it is not already being shown](https://github.com/nextcloud/gallery/blob/5b8cd55568ee582a52b8e7b17292579b87184712/js/gallery.js#L204). However, if the slideshow is closed while the drop down is being shown the gallery considers that the drop down is being shown (even if it is not visible to the user), so clicking on the share button does nothing in that case. Now the drop down is explicitly hidden when the slideshow is closed to ensure that the share button of the gallery works as expected.

Note that the problem was really minor because only the first click after closing the slideshow failed. [As that click was not done on the drop down the drop down was closed](https://github.com/nextcloud/gallery/blob/master/js/vendor/nextcloud/share.js#L967-L976), so the next time that the button was clicked the drop down was shown as expected.
