### PR TITLE
Put progress filling behind pause icon

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -98,7 +98,7 @@
 }
 
 #slideshow > .progress {
-	z-index: 1100;
+	z-index: 1099;
 	position: fixed;
 	bottom: 13px;
 	right: 13px;


### PR DESCRIPTION
The progress filling for the pause icon is a next sibling of the pause icon in the DOM. Both had the same z-index, so the progress filling element appeared in front of the pause icon. Due to this, if the pointer was hovering on the pause icon the hovered element could change from the pause icon to the progress filling when its height was increased, which in turn caused the highlight of the pause icon to disappear even if the pointer was not moved. Now the z-index of the progress filling was reduced to be shown behind the pause icon instead, which ensures that the pause icon is always the one being hovered.

Before:
![gallery-slideshow-pause-hover-before](https://user-images.githubusercontent.com/26858233/34656303-f0b1b6a2-f417-11e7-86d7-bc8455ed5b7a.png)

After:
![gallery-slideshow-pause-hover-after](https://user-images.githubusercontent.com/26858233/34656307-01d3f80a-f418-11e7-96d6-74a656e4b842.png)

Even if the progress is now shown behind the pause icon as both [the pause icon](https://github.com/nextcloud/gallery/blob/38d5fb6ffb4d7c06662713bd2a8858c6f8c1860b/css/slideshow.css#L42) and [the progress filling](https://github.com/nextcloud/gallery/blob/38d5fb6ffb4d7c06662713bd2a8858c6f8c1860b/css/slideshow.css#L107) use an opacity of 0.5, so visually it looks (almost) the same.

Before:
![gallery-slideshow-pause-before](https://user-images.githubusercontent.com/26858233/34656324-4a2621a0-f418-11e7-9b7c-721378fc192e.png)
![gallery-slideshow-pause-before-background](https://user-images.githubusercontent.com/26858233/34656325-4c272da0-f418-11e7-85f1-ee98003a514f.png)

After:
![gallery-slideshow-pause-after](https://user-images.githubusercontent.com/26858233/34656328-53491a3a-f418-11e7-9960-1fac5d6ed1cc.png)
![gallery-slideshow-pause-after-background](https://user-images.githubusercontent.com/26858233/34656330-5521de6e-f418-11e7-9c80-2a97cc2b8a06.png)

The problem happens too in the _stable12_ branch, but I do not know if this is worth backporting (probably not, but I would have no problem to do it ;-) ).

@nextcloud/designers 
