### PR TITLE
Unify slideshow share button with the rest of slideshow buttons

### DIFF
--- a/css/slideshow.css
+++ b/css/slideshow.css
@@ -47,7 +47,6 @@
 #slideshow.inactive > input,
 #slideshow.inactive > .progress,
 #slideshow.inactive > .slideshow-menu input,
-#slideshow.inactive > .slideshow-menu img,
 #slideshow.inactive > .name {
 	opacity: 0;
 	/* slow fadeout, fadein will be 300ms again*/
@@ -66,7 +65,6 @@
 
 #slideshow > input:hover,
 #slideshow > .slideshow-menu input:hover,
-#slideshow #slideshow-shared-button:hover,
 #slideshow.inactive > .name:hover {
 	opacity: 1;
 }
@@ -129,13 +127,6 @@
 	background-repeat: no-repeat;
 	background-color: transparent;
 	margin-right: 10px;
-}
-
-#slideshow .slideshow-menu .menuItem > img {
-	width: 24px;
-	height: 24px;
-	padding-top: 8px;
-	background: transparent;
 }
 
 #slideshow > .name {

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -520,6 +520,11 @@
 								el: '.deleteImage',
 								trans: t('gallery', 'Delete'),
 								toolTip: true
+							},
+							{
+								el: '.shareImage',
+								trans: t('gallery', 'Share'),
+								toolTip: true
 							}
 						];
 						for (var i = 0; i < buttonsArray.length; i++) {

--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -143,7 +143,7 @@
 				this.showButton('.deleteImage');
 			}
 			if (!isPublic && canShare) {
-				this.showButton('#slideshow-shared-button');
+				this.showButton('.shareImage');
 			}
 		},
 
@@ -154,7 +154,7 @@
 			this.hideButton('.changeBackground');
 			this.hideButton('.downloadImage');
 			this.hideButton('.deleteImage');
-			this.hideButton('#slideshow-shared-button');
+			this.hideButton('.shareImage');
 		},
 
 		/**
@@ -210,7 +210,7 @@
 		_specialButtonSetup: function (makeCallBack) {
 			this.container.find('.downloadImage').click(makeCallBack(this._getImageDownload));
 			this.container.find('.deleteImage').click(makeCallBack(this._deleteImage));
-			this.container.find('#slideshow-shared-button').click(makeCallBack(this.share));
+			this.container.find('.shareImage').click(makeCallBack(this.share));
 			this.container.find('.slideshow-menu').width = 52;
 			if (this.backgroundToggle) {
 				this.container.find('.changeBackground').click(

--- a/templates/slideshow.php
+++ b/templates/slideshow.php
@@ -10,7 +10,7 @@
 		<input type="button"
 			   class="menuItem svg downloadImage icon-download icon-shadow icon-white icon-32 hidden"/>
 		<input type="button"
-			   class="menuItem svg changeBackground icon-toggle-background icon-32 icon-shadow icon-white hidden"/>
+			   class="menuItem svg changeBackground icon-toggle-background icon-shadow icon-white icon-32 hidden"/>
 		<input type="button"
 			   class="menuItem svg deleteImage icon-delete icon-shadow icon-white icon-32 hidden">
 		<div id="slideshow-shared-button"

--- a/templates/slideshow.php
+++ b/templates/slideshow.php
@@ -13,9 +13,8 @@
 			   class="menuItem svg changeBackground icon-toggle-background icon-shadow icon-white icon-32 hidden"/>
 		<input type="button"
 			   class="menuItem svg deleteImage icon-delete icon-shadow icon-white icon-32 hidden"/>
-		<div id="slideshow-shared-button"
-			 class="menuItem svg button icon-share icon-shadow icon-white icon-32">
-		</div>
+		<input type="button"
+			   class="menuItem svg shareImage icon-share icon-shadow icon-white icon-32 hidden"/>
 		<a class="share" data-item-type="folder" data-item=""
 		   title="<?php p($l->t("Share")); ?>"
 		   data-possible-permissions="31">

--- a/templates/slideshow.php
+++ b/templates/slideshow.php
@@ -12,7 +12,7 @@
 		<input type="button"
 			   class="menuItem svg changeBackground icon-toggle-background icon-shadow icon-white icon-32 hidden"/>
 		<input type="button"
-			   class="menuItem svg deleteImage icon-delete icon-shadow icon-white icon-32 hidden">
+			   class="menuItem svg deleteImage icon-delete icon-shadow icon-white icon-32 hidden"/>
 		<div id="slideshow-shared-button"
 			 class="menuItem svg button icon-share icon-shadow icon-white icon-32">
 		</div>


### PR DESCRIPTION
The share button is now an input element like the rest of the slideshow buttons.

Besides getting a cleaner code it fixes the share button not being hidden like the rest of the slideshow buttons when the pointer was not moved for three seconds.

This pull request also cleans some related code and adds a tooltip for the _Share_ button.

In the _stable12_ branch the _Share_ button was hidden, but there was a small glitch: while the rest of the buttons fade from their current opacity (0.5) the _Share_ button first changed to an opacity of 1 and then faded, which made the _Share_ button look like it was highlighted.

If this is worth a backport tell me ;-)

@nextcloud/designers 
