### PR TITLE
Add missing tooltips to slideshow buttons

### DIFF
--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -492,11 +492,13 @@
 							},
 							{
 								el: '.play',
-								trans: t('gallery', 'Play')
+								trans: t('gallery', 'Play'),
+								toolTip: true
 							},
 							{
 								el: '.pause',
-								trans: t('gallery', 'Pause')
+								trans: t('gallery', 'Pause'),
+								toolTip: true
 							},
 							{
 								el: '.previous',
@@ -504,7 +506,8 @@
 							},
 							{
 								el: '.exit',
-								trans: t('gallery', 'Close')
+								trans: t('gallery', 'Close'),
+								toolTip: true
 							},
 							{
 								el: '.downloadImage',


### PR DESCRIPTION
Although this will be obsoleted when #276 is fixed until then the _Delete_ and _Download_ buttons had a tooltip, but the other buttons did not*, which was inconsistent. Now a tooltip was added for the _Close_, _Play_ and _Pause_ buttons.

*The _Share_ button already has a tooltip or not depending on whether #356 was merged or not when you read this :-)

Note, however, that tooltips where not added to the _Previous_ and _Next_ buttons as due to their extremely large area the tooltips appear too frequently and are more "noisy" than useful.

#355 is needed to prevent the tooltip for the _Pause_ icon to be hidden when the progress increases.

@nextcloud/designers 
