### PR TITLE
Fix loading icon position in "shareWith" field

### DIFF
--- a/css/share.css
+++ b/css/share.css
@@ -30,9 +30,10 @@
 	padding-left: 10px;
 }
 #dropdown.shareDropDown .shareWithLoading {
-	position: relative;
-	right: 70px;
-	top: 2px;
+	position: absolute;
+	padding: 11px;
+	right: 17px;
+	top: 18px;
 }
 #dropdown.shareDropDown .icon-loading-small.hidden {
 	display: none !important;

--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -341,7 +341,9 @@
 					delay: 750,
 					source: function (search, response) {
 						var $loading = $('#dropdown .shareWithLoading');
+						var $remoteInfo = $('#dropdown .shareWithRemoteInfo');
 						$loading.removeClass('hidden');
+						$remoteInfo.addClass('hidden');
 						$.get(OC.linkToOCS('apps/files_sharing/api/v1') + 'sharees', {
 							format: 'json',
 							search: search.term.trim(),
@@ -349,6 +351,7 @@
 							itemType: itemType
 						}, function (result) {
 							$loading.addClass('hidden');
+							$remoteInfo.removeClass('hidden');
 							if (result.ocs.meta.statuscode === 100) {
 								var users = result.ocs.data.exact.users.concat(result.ocs.data.users);
 								var groups = result.ocs.data.exact.groups.concat(result.ocs.data.groups);
@@ -419,6 +422,7 @@
 							}
 						}).fail(function () {
 							$('#dropdown').find('.shareWithLoading').addClass('hidden');
+							$('#dropdown').find('.shareWithRemoteInfo').removeClass('hidden');
 							OC.Notification.show(t('gallery', 'An error occured. Please try again'));
 							window.setTimeout(OC.Notification.hide, 5000);
 						});
@@ -461,7 +465,9 @@
 
 						var $input = $(this);
 						var $loading = $dropDown.find('.shareWithLoading');
+						var $remoteInfo = $dropDown.find('.shareWithRemoteInfo');
 						$loading.removeClass('hidden');
+						$remoteInfo.addClass('hidden');
 						$input.val(t('gallery', 'Adding user...'));
 						$input.prop('disabled', true);
 						Gallery.Share.share(
@@ -482,6 +488,7 @@
 							});
 						$input.prop('disabled', false);
 						$loading.addClass('hidden');
+						$remoteInfo.removeClass('hidden');
 						$('#shareWith').val('');
 						return false;
 					}


### PR DESCRIPTION
When searching or selecting a sharee in the _shareWith_ field a loading icon is shown. However, as the icon had a relative position and the _shareWith_ field uses the full width of the share dropdown the icon was shown in a new line below the field. Moreover, due to its `right` CSS property the icon was also shown outside the dropdown itself. Now, during the search for or the selection of a sharee, the loading icon replaces the information icon shown in the _shareWith_ field, just like done in the sharing section of the server.

Before (the icon is hardly visible, I should have used another background, I know :-) ):
![gallery-sharedropdown-loading-before](https://user-images.githubusercontent.com/26858233/35215111-9f765fe8-ff63-11e7-8be4-69f875d23d69.png)

After:
![gallery-sharedropdown-loading-after](https://user-images.githubusercontent.com/26858233/35215127-a5433824-ff63-11e7-90fc-72e4411e3aa0.png)

This should be backported to Nextcloud 13. It also happens in Nextcloud 12... worth a backport there?

@nextcloud/designers 
