### PR TITLE
Fix adding shares to wrong HTML element

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -872,7 +872,7 @@
 			}
 			html += '</div>';
 			html += '</li>';
-			html = $(html).appendTo('#shareWithList');
+			html = $(html).appendTo('#dropdown #shareWithList');
 			if (oc_config.enable_avatars === true) {
 				if (shareType === this.SHARE_TYPE_USER) {
 					html.find('.avatar').avatar(escapeHTML(shareWith), 32);


### PR DESCRIPTION
Fixes (in master) #300 

`_addShareWith` adds a share to the `#shareWithList` element, which is a descendant of the share dropdown. However, the _Sharing_ tab of the Files app sidebar contains its own `#shareWithList` element, so when the share dropdown is shown on top of the Files app (by clicking on an image
and then sharing it from the slideshow) and the _Sharing_ tab is open in the sidebar the share element ends added to the wrong element. To prevent this the matched element is now limited to descendants of the share dropdown.

Note, however, that there should not be two elements with the same ID in the same page. A better solution would have been to ensure that, but as [the sharing code seems to be going to be eventually removed from the gallery and replaced with a sidebar component from the server](https://github.com/nextcloud/gallery/issues/352#issuecomment-356532182) it was not worth to spend time on that ;-)
