### PR TITLE
Fix shortcuts activated when typing in the share dropdown

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -253,6 +253,10 @@
 		 */
 		_keyCodeSetup: function (makeCallBack) {
 			$(document).keyup(function (evt) {
+				if (evt.target.tagName.toLowerCase() === 'input') {
+					return;
+				}
+
 				var escKey = 27;
 				var leftKey = 37;
 				var rightKey = 39;


### PR DESCRIPTION
Fixes (in master) #272
Fixes (in master) #321

When in slideshow mode certain keys trigger actions like toggling full screen or zooming. However, due to event bubbling, those actions were triggered too when typing in the input fields of the share dropdown. Instead of stopping the propagation in each input field this is now fixed by not triggering the actions if the element that received the key press was an input field.
