### PR TITLE
Fix "connectToThumbnails" API test when run in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     packages:
       - graphviz
       - gdb
+      - ghostscript
   firefox: "latest"
 env:
   global:


### PR DESCRIPTION
Fixes #337 

[The server uses the Imagick PHP extension to generate PostScript previews](https://github.com/nextcloud/server/blob/3d4c698f448925aca62976175ffd4bab9694c7d6/lib/private/PreviewManager.php#L365-L384) and, in turn, [ImageMagick requires Ghostscript to handle PostScript files](http://www.imagemagick.org/script/formats.php). It seems that the base system used by Travis CI does not have Ghostscript installed by default, so it must be explicitly installed for the `connectToThumbnails` API test [to work as expected](https://github.com/nextcloud/gallery/blob/a2671c82233899376752a92cfe0fb45523832039/tests/api/ConnectWithTokenCest.php#L55).

By the way... if someone is bored, [some test images](https://github.com/nextcloud/gallery/commit/718e9be8a54ede8396819ef79ebd61bdba954a01#diff-e5d98399693e9648e6f713897c25ceb4) need an update :-P