### PR TITLE
Fix "SignInAsUser" acceptance test

### DIFF
--- a/tests/acceptance/SignInAsUserCept.php
+++ b/tests/acceptance/SignInAsUserCept.php
@@ -23,6 +23,6 @@ $loginPage = new Login($I);
 $loginPage->login('admin', 'admin');
 $loginPage->confirmLogin();
 
-$I->click('Gallery', '#appmenu');
+$I->click('//li[*[normalize-space(text()) = "Gallery"]]/a', '#appmenu');
 $I->seeCurrentUrlEquals(GalleryPage::$URL);
 $I->seeElement(['css' => GalleryPage::$contentDiv]);


### PR DESCRIPTION
~~Still **Developing** until the test run and confirm that it is fixed ;-)~~ Mmm, the issue that this pull request meant to fix is fixed, so I am changing it to **To review**.

However, there is still one test failing in one of the configurations (it seems that [the login fails when using PHP 7.0 and MySQL](https://travis-ci.org/nextcloud/gallery/jobs/332938158#L1778)). Maybe a timeout? Is it possible to restart a job in Travis CI?

Fixes #375 

The app menu markup has changed in the server. Before, [the image had an `alt` attribute with the name of the app](https://github.com/nextcloud/server/commit/927626cbaaa0da8be0800b6a635783aa3a8ac4ac#diff-8be54a6d336a8809304ef06b951698a9L55), so calling "click" with the app name was enough (as [`click` uses `selectLink`](https://github.com/Codeception/Codeception/blob/2.2.9/src/Codeception/Lib/InnerBrowser.php#L347), and [`selectLink` selected a clickable image by its `alt` attribute](https://symfony.com/doc/3.4/components/dom_crawler.html#links)). However, currently [menu icons no longer have that "alt" attribute](https://github.com/nextcloud/server/commit/927626cbaaa0da8be0800b6a635783aa3a8ac4ac#diff-8be54a6d336a8809304ef06b951698a9R53); as [the _Gallery_ text appears in a sibling element of the link](https://github.com/nextcloud/server/commit/927626cbaaa0da8be0800b6a635783aa3a8ac4ac#diff-8be54a6d336a8809304ef06b951698a9R59) clicking on _Gallery_ does nothing, so the link has to be located using an XPath expression instead.
