### PR TITLE
Fix "Sign in as user" acceptance test with PHP 7.0 and MySQL

### DIFF
--- a/tests/_support/Page/Acceptance/Login.php
+++ b/tests/_support/Page/Acceptance/Login.php
@@ -58,7 +58,9 @@ class Login {
 	public function confirmLogin() {
 		$I = $this->acceptanceTester;
 
+		// 30 is the default timeout used in the WebDriver extension for
+		// requests, so it is used here too for consistency
+		$I->waitForElement(['css' => FilesPage::$contentDiv], 30);
 		$I->seeInCurrentUrl(FilesPage::$URL);
-		$I->seeElement(['css' => FilesPage::$contentDiv]);
 	}
 }

--- a/tests/acceptance/SignInAsUserCept.php
+++ b/tests/acceptance/SignInAsUserCept.php
@@ -23,6 +23,7 @@ $loginPage = new Login($I);
 $loginPage->login('admin', 'admin');
 $loginPage->confirmLogin();
 
+$I->waitForElementVisible('//*[@id = "appmenu"]//li[*[normalize-space(text()) = "Gallery"]]/a', 30);
 $I->click('//li[*[normalize-space(text()) = "Gallery"]]/a', '#appmenu');
 $I->seeCurrentUrlEquals(GalleryPage::$URL);
 $I->seeElement(['css' => GalleryPage::$contentDiv]);


### PR DESCRIPTION
It seems that the tests run slower on PHP 7.0 and MySQL in Travis CI (probably due to the use of XDebug); this caused the _Sign in as user_ acceptance test to fail when some actions were executed on an element that had not appeared yet. To fix that now it is checked that the offending elements have appeared in the page before trying to use them.
