### PR TITLE
Fix timeout in API tests

### DIFF
--- a/tests/api.suite.yml
+++ b/tests/api.suite.yml
@@ -7,3 +7,6 @@ modules:
         - REST:
             url: http://localhost:8000
             depends: PhpBrowser
+        - PhpBrowser:
+            url: http://localhost:8000
+            timeout: 60


### PR DESCRIPTION
When run on PHP 7.0 and MySQL in Travis CI sometimes the API tests fail with a timeout; it seems that the tests are slower in that environment, so the timeout has to be increased in that case.

Increasing the timeout simply gives slower tests more time to finish the requests, but it does not affect the other tests in any way, so the timeout was increased for every test.

And with this... we are finally back in green! :-D
