### PR TITLE
[stable11] Make acceptance tests run and pass on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
       - graphviz
       - gdb
       - ghostscript
+  firefox: "latest"
 env:
   global:
     - CORE_BRANCH=stable11
@@ -46,8 +47,12 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
-  - sh -c "if [ ! -e ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar ]; then wget -O ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar https://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.0.jar; fi;"
-  - java -jar ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar -port 4444 >/dev/null 2>&1 & # WARNING - Takes a long time to start up. Keep here
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.19.1/geckodriver-v0.19.1-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
+  - sh -c "wget -O ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar https://selenium-release.storage.googleapis.com/3.7/selenium-server-standalone-3.7.1.jar;"
+  - java -jar ${TRAVIS_BUILD_DIR}/travis/lib-cache/selenium.jar -port 4444 -enablePassThrough false >/dev/null 2>&1 & # WARNING - Takes a long time to start up. Keep here
 
   # Ghostdriver does not work on Travis - Download the latest PhantomJS
   #- mkdir travis-phantomjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,7 @@ after_success:
 
 after_failure:
   - cat tests/_output/phpbuiltinserver.errors.txt
+  - cat tests/_output/phpbuiltinserver.access_log.txt
   - bash build/after_failure.sh
 
 matrix:


### PR DESCRIPTION
Backport of #330

Fixes https://github.com/nextcloud/gallery/pull/386#issuecomment-361259941

The first two commits of the original pull request are not included in this backport; the first one added the package dbus-x11, which was later removed in #333, and the second one upgraded Codeception to 2.3, which was not really needed (and without an update to composer.lock had no effect).
