### PR TITLE
Fix share drop down in gallery not properly shown

### DIFF
--- a/css/share.css
+++ b/css/share.css
@@ -154,8 +154,12 @@ a.unshare {
 	padding: 17px;
 }
 
+#controls #linkSocial {
+	right: -3px;
+}
+
 #slideshow #linkSocial {
-	right: -5px;
+	right: -6px;
 }
 
 #linkSocial .icon {

--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -955,7 +955,7 @@ $(document).ready(function () {
 		if ($(this).data('item-type') !== undefined && $(this).data('path') !== undefined) {
 			var itemType = $(this).data('item-type');
 			var path = $(this).data('path');
-			var appendTo = $(this).parent().parent();
+			var appendTo = $(this).parents('#controls, #slideshow')[0];
 			var link = false;
 			var possiblePermissions = $(this).data('possible-permissions');
 			if ($(this).data('link') !== undefined && $(this).data('link') == true) {


### PR DESCRIPTION
Fixes #352 (please see there for screenshots ;-) )

The first three issues were fixed by appending the share drop down to the `#controls` element when shown in the gallery; overriding the CSS rules was not very maintainable as explained in #352, and adding a specific class to inputs and buttons in the actions bar was discarded because those elements belong to the actions bar; it is the share drop down the one that happened to be there, and thus the proper actions bar elements should not be modified just to accommodate "alien" elements.

Note, however, that there are still some slight style differences in the share dropdown when shown in the gallery or in the slideshow (due to the CSS rules for `#controls` descendants), but only minor details and nothing clearly bad like before (for example, input fields height in one case is 34px and in other 36px).

Due to those slight differences the `right` position used to center the tip of the social sharing menu is different depending on whether the share drop down is shown in the gallery or in the slideshow.

After taking a more careful look, I noticed that the social sharing menu was off by 1 pixel also when the share drop down was shown in the slideshow; this has been addressed too in this pull request.

Finally, as Nextcloud 13 is still _tender_ and [the social sharing menu in my opinion gives a bad impression without the fix](https://github.com/nextcloud/gallery/issues/352#issuecomment-357224433) I would backport this to _stable13_.

@nextcloud/designers 
