### PR TITLE
Fix gallery button hidden in folders without create permission

### DIFF
--- a/css/gallerybutton.css
+++ b/css/gallerybutton.css
@@ -4,6 +4,11 @@
 	margin-left: auto;
 }
 
+#controls .button.view-switcher:not(.gallery) {
+	margin-top: 5px;
+	margin-right: 5px;
+}
+
 #controls .button.view-switcher.gallery {
 	margin-right: 4px;
 	padding: 9px 11px;

--- a/js/gallerybutton.js
+++ b/js/gallerybutton.js
@@ -81,7 +81,7 @@ $(document).ready(function () {
 				window.location.href = GalleryButton.url;
 			});
 
-			$('#controls .actions').append(GalleryButton.button);
+			$('#controls').append(GalleryButton.button);
 		}
 	}
 );


### PR DESCRIPTION
This pull request ensures that the button to switch to the Gallery app is shown in read-only folders.

This is necessary for the fix introduced in nextcloud/server#8589, and it requires nextcloud/server#8588.
