### PR TITLE
Fix controls position in gallery layout

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -5,9 +5,12 @@ body {
 }
 
 #content {
-	height: initial;
+	/* #content is the previous sibling of the footer, so its height must match
+	 * the height of its child elements to prevent the footer from overlapping
+	 * them. The server sets "height: 100%" for #content, so that value has to
+	 * be overriden. */
+	height: auto;
 	min-height: calc(100vh - 103px); /* 45px(#controls) + 58px(footer) = 103px */
-	overflow: hidden;
 }
 
 /* height fix for ie11 */

--- a/css/styles.css
+++ b/css/styles.css
@@ -8,7 +8,6 @@ body:after {
 
 #controls {
 	width: 100%;
-	top: 45px;
 }
 
 .breadcrumbs-droppable-hover {
@@ -82,11 +81,20 @@ div.crumb.last a {
 #content-wrapper {
 	position: relative;
 	height: calc(100vh - 45px); /* 45px for #controls element */
+	top: 45px;
 	padding: 0;
 	overflow-x: auto;
 	-webkit-overflow-scrolling: touch;
 	-webkit-transition: background-color 1s linear;
 	transition: background-color 1s linear;
+}
+
+#app {
+	/* #app is the parent of #controls and #gallery, and #controls uses a sticky
+	 * position, so the #app height must contain the full gallery for the
+	 * controls to be stuck while scrolling. The server sets "height: 100%" for
+	 * the app, so that value has to be overriden. */
+	height: auto;
 }
 
 #gallery.hascontrols {

--- a/css/styles.css
+++ b/css/styles.css
@@ -103,6 +103,9 @@ div.crumb.last a {
 	text-align: justify;
 	padding-bottom: 10px;
 	margin-bottom: 45px;
+
+	/* Override unneeded margin from server */
+	margin-top: 0;
 }
 
 #gallery .row {

--- a/js/app.js
+++ b/js/app.js
@@ -12,7 +12,7 @@
 /* global OC, $, _, Gallery, SlideShow */
 $(document).ready(function () {
 	"use strict";
-	$('#controls').insertBefore($('#content-wrapper'));
+	$('#controls').prependTo($('#app'));
 	Gallery.utility = new Gallery.Utility();
 	Gallery.view = new Gallery.View();
 	Gallery.token = Gallery.utility.getPublicToken();


### PR DESCRIPTION
This pull request addresses [a comment in #350](https://github.com/nextcloud/gallery/issues/350#issuecomment-366921663), although it does not fix the original issue there (the comment is unrelated to the issue, but it has good information ;-) ).

The problem was that the `#controls` element was added outside the `#content-wrapper` element. This caused the controls to overlap the scroll bar of the contents, and also the controls to the right to be hidden when the sidebar of the _JavaScript XMPP Chat_ was open.

Before:
![gallery-controls-before](https://user-images.githubusercontent.com/26858233/37077609-f795f388-21db-11e8-9df4-b37dcbc879ec.png)

After:
![gallery-controls-after](https://user-images.githubusercontent.com/26858233/37077685-50038666-21dc-11e8-8ed8-b0ab715ccf60.png)

To fix that the `#controls` element was moved inside the `#app` element and the styles were adjusted to keep the same appearance and scrolling behaviour as before.

Note, however, that `#content-wrapper` is kept as the scrolling container; in order to reduce the styles overriden from the server it would be better to make `#app` the scrolling container. The problem is that although it would work nicely in the main gallery it would require some changes to the gallery of the public share page (due to the footer element, which is outside the `#app` element). Given that the gallery of the public share page is going to be modified soon for the time being I just left it as is.

When testing this note that the public sharing page of current _master_ branch of the Gallery does not work on current _master_ branch of the server (that is why it is going to be modified soon ;-) ). You have to use a commit prior to nextcloud/server@01f420c7ac38128c03975d7de7dd20190c4afcc1

@nextcloud/designers
