### PR TITLE
Fix position of icons in "Share with" input field

### DIFF
--- a/css/share.css
+++ b/css/share.css
@@ -35,6 +35,13 @@
 	right: 17px;
 	top: 18px;
 }
+#app #dropdown.shareDropDown .shareWithLoading {
+	/* The "box-sizing" of "#app" descendants is set to "border-box" in the
+	 * server. To have the same size the padding here has to be set to the
+	 * min-width/min-height plus the padding set for the icon in the default
+	 * "content-box" sizing. */
+	padding: 19px;
+}
 #dropdown.shareDropDown .icon-loading-small.hidden {
 	display: none !important;
 }
@@ -43,6 +50,14 @@
 	padding: 11px;
 	right: 17px;
 	top: 18px;
+}
+
+#app #dropdown .shareWithRemoteInfo {
+	/* The "box-sizing" of "#app" descendants is set to "border-box" in the
+	 * server. To have the same size the padding here has to be set to the
+	 * min-width/min-height plus the padding set for the icon in the default
+	 * "content-box" sizing. */
+	padding: 19px;
 }
 
 #dropdown .avatar {


### PR DESCRIPTION
This pull request fixes a regression introduced (by me :-P ) in #404.

The `box-sizing` of `#app` descendants is set to `border-box` in the server. Depending on where it is shown, the _Share with_ input field can be a descendant of `#app` or not, so its icons either use the
`border-box` or the `content-box` sizing depending on the case (`border-box` is used when shown in the main gallery layout, while `content-box` is used when shown in the slideshow layout). Therefore, the padding when using `border-box` sizing has to be set to the content size (`min-width` and `min-height`) plus the padding used in `content-box` sizing.

**Before** (share dialog of an album in gallery layout):
![gallery-share-icon-info-before](https://user-images.githubusercontent.com/26858233/37735997-fbadb5e4-2d4f-11e8-9879-bc7ea3111749.png)
![gallery-share-icon-loading-before](https://user-images.githubusercontent.com/26858233/37736001-fda907b8-2d4f-11e8-8731-0961eb831803.png)

**After** (share dialog of an album in gallery layout):
![gallery-share-icon-info-after](https://user-images.githubusercontent.com/26858233/37736007-ffc1722e-2d4f-11e8-81ef-b81e2ff8f6fe.png)
![gallery-share-icon-loading-after](https://user-images.githubusercontent.com/26858233/37736014-01b59592-2d50-11e8-9ba0-2fbd117c0e6f.png)
