### PR TITLE
Fix "No results found" tooltip

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -514,6 +514,12 @@
 						.appendTo(ul);
 				};
 
+				$('#shareWith').on('input', function () {
+					if ($(this).val().length < 2) {
+						$(this).removeClass('error').tooltip('hide');
+					}
+				});
+
 				if (link && linksAllowed && $('#email').length != 0) {
 					$('#email').autocomplete({
 						minLength: 1,

--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -403,7 +403,7 @@
 
 								} else {
 									var title = t('gallery', 'No users or groups found for {search}', {search: $('#shareWith').val()});
-									if (!view.configModel.get('allowGroupSharing')) {
+									if (!oc_appconfig.core.allowGroupSharing) {
 										title = t('gallery', 'No users found for {search}', {search: $('#shareWith').val()});
 									}
 									$('#shareWith').addClass('error')


### PR DESCRIPTION
This pull request fixes the _No results found_ tooltip not being shown. It also adds the code needed to hide it based on the one used in the server.

Note, however, that is does not address the problems with that code (for example, if a search is started and while it is being performed the input field is cleared the tooltip would be still shown once the search response is received, even if the input field is now empty).

Probably not worth a backport, although it should be straightforward to do it.

**How to test:**
- Open an album in the Gallery app
- Show the _Share_ dialog for the album
- In the search field type the name of a user that does not exist

**Expected result:**
A _No results found_ tooltip is shown for the input field; if the input field is emptied the tooltip goes away.

**Actual result:**
No tooltip is shown.
