### PR TITLE
Fix UI while a share is being added

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -485,11 +485,26 @@
 								Gallery.Share._addShareWith(data.id, shareType, shareWith,
 									selected.item.label,
 									permissions, posPermissions);
+
+								$input.val('');
+								$input.prop('disabled', false);
+
+								$loading.addClass('hidden');
+								$remoteInfo.removeClass('hidden');
+							},
+							function (result) {
+								var message = t('gallery', 'Error');
+								if (result && result.ocs && result.ocs.meta && result.ocs.meta.message) {
+									message = result.ocs.meta.message;
+								}
+								OC.Notification.showTemporary(message);
+
+								$input.val(shareWith);
+								$input.prop('disabled', false);
+
+								$loading.addClass('hidden');
+								$remoteInfo.removeClass('hidden');
 							});
-						$input.prop('disabled', false);
-						$loading.addClass('hidden');
-						$remoteInfo.removeClass('hidden');
-						$('#shareWith').val('');
 						return false;
 					}
 				}).data("ui-autocomplete")._renderItem = function (ul, item) {


### PR DESCRIPTION
After calling `Gallery.Share.share` the UI was restored (the working icon was hidden, the input field enabled...). However, `share` is asynchronous, so the UI was restored while the share was still being
added. Now the UI is restored in the share callbacks, so it is restored once the sharing finished, either successfully or with a failure; in this later case now a notification is also shown.

Probably not worth a backport, although it should be straightforward to do it.

**How to test**
- Modify the code of ShareAPIController and add `sleep(10);` to [the beginning of the `create` method](https://github.com/nextcloud/server/blob/2c073dc53d24c82dd4aaf315327d08463f2c7050/apps/files_sharing/lib/Controller/ShareAPIController.php#L343) to simulate a slow server
- Open an album in the Gallery app
- Show the _Share_ dialog for the album
- In the search field type the name of a user that exists
- Click on the name of that user shown in the dropdown to add the share

**Expected result**
The input field is disabled and the working icon is shown until the share is finally added.

**Actual result**
The input field is enabled and the working icon is hidden immediately.
