### PR TITLE
Hide "No results found" tooltip on autocompletion

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -340,10 +340,15 @@
 					minLength: 2,
 					delay: 750,
 					source: function (search, response) {
+						var $shareWithField = $('#dropdown #shareWith');
 						var $loading = $('#dropdown .shareWithLoading');
 						var $remoteInfo = $('#dropdown .shareWithRemoteInfo');
 						$loading.removeClass('hidden');
 						$remoteInfo.addClass('hidden');
+
+						$shareWithField.removeClass('error')
+							.tooltip('hide');
+
 						$.get(OC.linkToOCS('apps/files_sharing/api/v1') + 'sharees', {
 							format: 'json',
 							search: search.term.trim(),


### PR DESCRIPTION
Follow-up to #415 

If the tooltip is not explicitly hidden it would still be shown once the autocompletion dropdown is shown (behind it while it is open, but fully visible when it is closed).

This unifies its behaviour with the one used in the server, but it does not address its problems (for example, if a search is started and while it is being performed the input field is cleared the tooltip would be still shown once the search response is received, even if the input field is now empty).

**How to test:**
- Open an album in the Gallery app
- Show the Share dialog for the album
- In the search field type the name of a user that exists, and then add any letter to it; the _No results found_ tooltip is shown.
- Remove the extra letter; the autocompletion dropdown is shown
- Click on an empty space of the share dialog to close the autocompletion dropdown

**Expected result:**
No tooltip is visible.

**Actual result:**
The _No results found_ tooltip is still visible.
