### PR TITLE
Public page response

### DIFF
--- a/css/public.css
+++ b/css/public.css
@@ -18,46 +18,6 @@ html.ie #content {
 	height: auto;
 }
 
-/* within #save */
-#save .save-form {
-	position: relative;
-}
-
-#remote_address {
-	margin: 0;
-	width: 130px;
-	height: 14px;
-	padding: 6px;
-	padding-right: 24px;
-}
-
-#save #save-button,
-#save #save-button-confirm {
-	margin: 0 5px;
-	height: 28px;
-	padding-bottom: 4px;
-	line-height: 14px;
-}
-
-#save-button-confirm {
-	position: absolute;
-	background-color: transparent;
-	border: none;
-	margin: 2px 4px !important;
-	right: 0;
-	opacity: .5;
-}
-
-#save-button-confirm:disabled, #save-button-confirm:disabled:hover, #save-button-confirm:disabled:focus {
-    opacity: .2;
-    cursor: default;
-}
-
-#save-button-confirm:hover,
-#save-button-confirm:focus {
-	opacity: 1;
-}
-
 #gallery.hascontrols {
 	padding-bottom: 0;
 }

--- a/css/public.css
+++ b/css/public.css
@@ -1,18 +1,3 @@
-body {
-	position: absolute;
-	height: 100%;
-	width: 100%;
-}
-
-#content {
-	/* #content is the previous sibling of the footer, so its height must match
-	 * the height of its child elements to prevent the footer from overlapping
-	 * them. The server sets "height: 100%" for #content, so that value has to
-	 * be overriden. */
-	height: auto;
-	min-height: calc(100vh - 103px); /* 45px(#controls) + 58px(footer) = 103px */
-}
-
 /* height fix for ie11 */
 html.ie #content {
 	height: auto;

--- a/css/styles.css
+++ b/css/styles.css
@@ -78,17 +78,6 @@ div.crumb.last a {
 	list-style: initial;
 }
 
-#content-wrapper {
-	position: relative;
-	height: calc(100vh - 45px); /* 45px for #controls element */
-	top: 45px;
-	padding: 0;
-	overflow-x: auto;
-	-webkit-overflow-scrolling: touch;
-	-webkit-transition: background-color 1s linear;
-	transition: background-color 1s linear;
-}
-
 #app {
 	/* #app is the parent of #controls and #gallery, and #controls uses a sticky
 	 * position, so the #app height must contain the full gallery for the

--- a/js/breadcrumb.js
+++ b/js/breadcrumb.js
@@ -133,7 +133,7 @@
 		 */
 		_build: function () {
 			var i, crumbs, name, path, currentAlbum;
-			var albumName = $('#content').data('albumname');
+			var albumName = $('#app').data('albumname');
 			if (!albumName) {
 				albumName = t('gallery', 'Gallery');
 			}

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -222,7 +222,7 @@
 		download: function (event) {
 			event.preventDefault();
 
-			var path = $('#content').data('albumname');
+			var path = $('#app').data('albumname');
 			var files = Gallery.currentAlbum;
 			var downloadUrl = Gallery.utility.buildFilesUrl(path, files);
 

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -240,15 +240,6 @@
 		},
 
 		/**
-		 * Lets the user add the shared files to his cloud
-		 */
-		showSaveForm: function () {
-			$(this).hide();
-			$('.save-form').css('display', 'inline');
-			$('#remote_address').focus();
-		},
-
-		/**
 		 * Sends the shared files to the viewer's cloud
 		 *
 		 * @param event
@@ -256,7 +247,7 @@
 		saveForm: function (event) {
 			event.preventDefault();
 
-			var saveElement = $('#save');
+			var saveElement = $('#save-external-share');
 			var remote = $(this).find('input[type="text"]').val();
 			var owner = saveElement.data('owner');
 			var name = saveElement.data('name');

--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -375,7 +375,6 @@
 			$('#album-info-button').click(Gallery.showInfo);
 			$('#sort-name-button').click(Gallery.sorter);
 			$('#sort-date-button').click(Gallery.sorter);
-			$('#save #save-button').click(Gallery.showSaveForm);
 			$('.save-form').submit(Gallery.saveForm);
 			this._renderNewButton();
 			// Trigger cancelling of file upload

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -51,6 +51,7 @@ use OCA\Gallery\Middleware\EnvCheckMiddleware;
 use OCA\Gallery\Utility\EventSource;
 
 use OCA\OcUtility\AppInfo\Application as OcUtility;
+use OCP\IL10N;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -81,7 +82,8 @@ class Application extends App {
 				$c->query('Environment'),
 				$c->query('OCP\IURLGenerator'),
 				$c->query('OCP\IConfig'),
-				$c->query(EventDispatcherInterface::class)
+				$c->query(EventDispatcherInterface::class),
+				$c->query(IL10N::class)
 			);
 		}
 		);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -14,8 +14,8 @@
 
 namespace OCA\Gallery\Controller;
 
-use OCA\Files_Sharing\Template\ExternalShareMenuAction;
-use OCA\Files_Sharing\Template\LinkMenuAction;
+use OCP\AppFramework\Http\Template\ExternalShareMenuAction;
+use OCP\AppFramework\Http\Template\LinkMenuAction;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\Template\SimpleMenuAction;
 use OCP\IL10N;

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -118,7 +118,7 @@ class PageController extends Controller {
 	 * @param string $token
 	 * @param null|string $filename
 	 *
-	 * @return TemplateResponse|ImageResponse|RedirectResponse
+	 * @return PublicTemplateResponse|ImageResponse|RedirectResponse
 	 */
 	public function publicIndex($token, $filename) {
 		$node = $this->environment->getSharedNode();

--- a/templates/public.php
+++ b/templates/public.php
@@ -24,61 +24,53 @@ style(
 style('files_sharing', 'public');
 
 ?>
-<div id="content-wrapper">
-	<div id="content" class="app-<?php p($_['appName']) ?>"
-		 data-albumname="<?php p($_['albumName']) ?>">
-		<div id="app">
-			<div id="controls">
-				<div id="breadcrumbs"></div>
-				<!-- sorting buttons -->
-				<div class="buttons">
-					<div id="sort-name-button" class="button sorting left-switch-button">
-						<div class="flipper">
-							<img class="svg asc front" src="<?php print_unescaped(
-								image_path($_['appName'], 'nameasc.svg')
-							); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
-							<img class="svg des back" src="<?php print_unescaped(
-								image_path($_['appName'], 'namedes.svg')
-							); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
-						</div>
-					</div>
-					<div id="sort-date-button" class="button sorting right-switch-button">
-						<div class="flipper">
-							<img class="svg asc front" src="<?php print_unescaped(
-								image_path($_['appName'], 'dateasc.svg')
-							); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
-							<img class="svg des back" src="<?php print_unescaped(
-								image_path($_['appName'], 'datedes.svg')
-							); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
-						</div>
-					</div>
-					<div id="album-info-button" class="button">
-						<span class="ribbon black"></span>
-						<img class="svg" src="<?php print_unescaped(
-							image_path('core', 'actions/info.svg')
-						); ?>" alt="<?php p($l->t('Album information')); ?>"/>
-					</div>
-					<div class="album-info-container">
-						<div class="album-info-loader"></div>
-						<div class="album-info-content markdown-body"></div>
-					</div>
-					<!-- toggle for opening the current album as file list -->
-					<div id="filelist-button" class="button view-switcher gallery">
-						<div id="button-loading" class="hidden"></div>
-						<img class="svg" src="<?php print_unescaped(
-							image_path('core', 'actions/toggle-filelist.svg')
-						); ?>" alt="<?php p($l->t('Picture view')); ?>"/>
-					</div>
+<div id="app" data-albumname="<?php p($_['albumName']) ?>">
+	<div id="controls">
+		<div id="breadcrumbs"></div>
+		<!-- sorting buttons -->
+		<div class="buttons">
+			<div id="sort-name-button" class="button sorting left-switch-button">
+				<div class="flipper">
+					<img class="svg asc front" src="<?php print_unescaped(
+						image_path($_['appName'], 'nameasc.svg')
+					); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
+					<img class="svg des back" src="<?php print_unescaped(
+						image_path($_['appName'], 'namedes.svg')
+					); ?>" alt="<?php p($l->t('Sort by name')); ?>"/>
 				</div>
 			</div>
-			<div id="gallery" class="hascontrols"
-				 data-requesttoken="<?php p($_['requesttoken']) ?>"
-				 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
+			<div id="sort-date-button" class="button sorting right-switch-button">
+				<div class="flipper">
+					<img class="svg asc front" src="<?php print_unescaped(
+						image_path($_['appName'], 'dateasc.svg')
+					); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
+					<img class="svg des back" src="<?php print_unescaped(
+						image_path($_['appName'], 'datedes.svg')
+					); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
+				</div>
 			</div>
-			<div id="emptycontent" class="hidden"></div>
+			<div id="album-info-button" class="button">
+				<span class="ribbon black"></span>
+				<img class="svg" src="<?php print_unescaped(
+					image_path('core', 'actions/info.svg')
+				); ?>" alt="<?php p($l->t('Album information')); ?>"/>
+			</div>
+			<div class="album-info-container">
+				<div class="album-info-loader"></div>
+				<div class="album-info-content markdown-body"></div>
+			</div>
+			<!-- toggle for opening the current album as file list -->
+			<div id="filelist-button" class="button view-switcher gallery">
+				<div id="button-loading" class="hidden"></div>
+				<img class="svg" src="<?php print_unescaped(
+					image_path('core', 'actions/toggle-filelist.svg')
+				); ?>" alt="<?php p($l->t('Picture view')); ?>"/>
+			</div>
 		</div>
 	</div>
-	<footer>
-		<p class="info"><?php print_unescaped($theme->getLongFooter()); ?></p>
-	</footer>
+	<div id="gallery" class="hascontrols"
+		 data-requesttoken="<?php p($_['requesttoken']) ?>"
+		 data-token="<?php isset($_['token']) ? p($_['token']) : p(false) ?>">
+	</div>
+	<div id="emptycontent" class="hidden"></div>
 </div>

--- a/templates/public.php
+++ b/templates/public.php
@@ -21,52 +21,9 @@ style(
 		'gallerybutton'
 	]
 );
+style('files_sharing', 'public');
 
 ?>
-<div id="notification-container">
-	<div id="notification" style="display: none;"></div>
-</div>
-<header>
-	<div id="header">
-		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
-		   title="" id="nextcloud">
-			<div class="logo logo-icon svg">
-			</div>
-		</a>
-
-		<div class="header-appname-container">
-			<h1 class="header-appname">
-				<?php print_unescaped($theme->getHTMLName()); ?>
-			</h1>
-		</div>
-
-		<div class="header-right">
-			<span id="details">
-				<?php
-				if ($_['server2ServerSharing']) {
-					?>
-					<span id="save" data-protected="<?php p($_['protected']) ?>"
-						  data-owner="<?php p($_['displayName']) ?>"
-						  data-name="<?php p($_['filename']) ?>">
-									<button id="save-button"><?php p(
-											$l->t('Add to your Nextcloud')
-										) ?></button>
-									<form class="save-form hidden" action="#">
-										<input type="text" id="remote_address"
-											   placeholder="user@yourNextcloud.org"/>
-										<button id="save-button-confirm"
-												class="icon-confirm svg" disabled></button>
-									</form>
-								</span>
-				<?php } ?>
-				<a id="download" class="button">
-					<span class="icon-download"></span>
-					<span id="download-text"><?php p($l->t('Download')) ?></span>
-				</a>
-			</span>
-		</div>
-	</div>
-</header>
 <div id="content-wrapper">
 	<div id="content" class="app-<?php p($_['appName']) ?>"
 		 data-albumname="<?php p($_['albumName']) ?>">


### PR DESCRIPTION
Use the new PublicPageResponse for NC14+ to render public pages that have the same header actions as the files_sharing app.

Fixes https://github.com/nextcloud/gallery/issues/403 and https://github.com/nextcloud/gallery/issues/358

Requires https://github.com/nextcloud/server/pull/9084

![image](https://user-images.githubusercontent.com/3404133/38363560-6539297c-38d5-11e8-8dcc-eeb3b7add7a9.png)
