### PR TITLE
Move from EventSource loading to individual requests

### DIFF
--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -162,16 +162,10 @@ window.Gallery = window.Gallery || {};
 
 			/* jshint camelcase: false */
 			var params = {
-				fileId: fileId,
 				width: longEdge,
 				height: longEdge,
-				a: 1
 			};
-			if (Gallery.token) {
-				// TODO: return link for public pages
-				return this.buildGalleryUrl('preview', '/' + fileId, params);
-			}
-			return OC.generateUrl('core/preview?fileId={fileId}&x={width}&y={width}&a={a}', params);
+			return this.buildGalleryUrl('preview', '/' + fileId, params);
 		},
 
 		/**

--- a/js/galleryutility.js
+++ b/js/galleryutility.js
@@ -162,12 +162,16 @@ window.Gallery = window.Gallery || {};
 
 			/* jshint camelcase: false */
 			var params = {
-				c: etag,
+				fileId: fileId,
 				width: longEdge,
 				height: longEdge,
-				requesttoken: oc_requesttoken
+				a: 1
 			};
-			return this.buildGalleryUrl('preview', '/' + fileId, params);
+			if (Gallery.token) {
+				// TODO: return link for public pages
+				return this.buildGalleryUrl('preview', '/' + fileId, params);
+			}
+			return OC.generateUrl('core/preview?fileId={fileId}&x={width}&y={width}&a={a}', params);
 		},
 
 		/**

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -129,7 +129,11 @@ function Thumbnail (fileId, square) {
 						thumb.loadingDeferred.resolve(null);
 					};
 					var width = square ? 200 : 400;
-					thumb.image.src = Gallery.utility.buildGalleryUrl('preview', '/' + id, {width: width, height: 200}) + '&requesttoken=' + encodeURIComponent(oc_requesttoken);
+					if (Gallery.token) {
+						thumb.image.src = Gallery.utility.buildGalleryUrl('preview', '/' + id, {width: width, height: 200});
+					} else {
+						thumb.image.src = OC.generateUrl('core/preview?fileId={fileId}&x={width}&y={width}&a={a}', {fileId: id, width: width, a: 1});
+					}
 				});
 			}
 

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -129,11 +129,7 @@ function Thumbnail (fileId, square) {
 						thumb.loadingDeferred.resolve(null);
 					};
 					var width = square ? 200 : 400;
-					if (Gallery.token) {
-						thumb.image.src = Gallery.utility.buildGalleryUrl('preview', '/' + id, {width: width, height: 200});
-					} else {
-						thumb.image.src = OC.generateUrl('core/preview?fileId={fileId}&x={width}&y={width}&a={a}', {fileId: id, width: width, a: 1});
-					}
+					thumb.image.src = Gallery.utility.buildGalleryUrl('preview', '/' + id, {width: width, height: 200});
 				});
 			}
 

--- a/js/thumbnail.js
+++ b/js/thumbnail.js
@@ -108,60 +108,29 @@ function Thumbnail (fileId, square) {
 			var batch = {};
 			var i, idsLength = ids.length;
 			if (idsLength) {
-				for (i = 0; i < idsLength; i++) {
-					var thumb = new Thumbnail(ids[i], square);
+				_.each(ids, function(id) {
+					var thumb = new Thumbnail(id, square);
 					thumb.image = new Image();
-					map[ids[i]] = batch[ids[i]] = thumb;
+					map[id] = batch[id] = thumb;
 
-				}
-				var params = {
-					ids: ids.join(';'),
-					scale: window.devicePixelRatio,
-					square: (square) ? 1 : 0
-				};
-				var url = Gallery.utility.buildGalleryUrl('thumbnails', '', params);
-
-				var eventSource = new Gallery.EventSource(url);
-				eventSource.listen('preview',
-					function (/**{path, status, mimetype, preview}*/ preview) {
-						var id = preview.fileid;
-						var thumb = batch[id];
-						thumb.status = preview.status;
-						if (thumb.status === 404) {
-							thumb.valid = false;
-							thumb.loadingDeferred.resolve(null);
-						} else {
-							thumb.image.onload = function () {
-								// Fix for SVG files which can come in all sizes
-								if (square) {
-									thumb.image.width = 200;
-									thumb.image.height = 200;
-								}
-								thumb.ratio = thumb.image.width / thumb.image.height;
-								thumb.image.originalWidth = 200 * thumb.ratio;
-								thumb.loadingDeferred.resolve(thumb.image);
-							};
-							thumb.image.onerror = function () {
-								thumb.valid = false;
-								var icon = OC.MimeType.getIconUrl(preview.mimetype);
-								setTimeout(function () {
-									thumb.image.src = icon;
-								}, 0);
-							};
-
-							if (thumb.status === 200) {
-								var imageData = preview.preview;
-								if (preview.mimetype === 'image/svg+xml') {
-									imageData = Thumbnails._purifySvg(imageData);
-								}
-								thumb.image.src =
-									'data:' + preview.mimetype + ';base64,' + imageData;
-							} else {
-								thumb.valid = false;
-								thumb.image.src = OC.MimeType.getIconUrl(preview.mimetype);
-							}
+					thumb.image.onload = function () {
+						if (square) {
+							thumb.image.width = 200;
+							thumb.image.height = 200;
 						}
-					});
+						thumb.ratio = thumb.image.width / thumb.image.height;
+						thumb.image.originalWidth = 200 * thumb.ratio;
+						thumb.valid = true;
+						thumb.status = 200;
+						thumb.loadingDeferred.resolve(thumb.image);
+						console.log(thumb);
+					};
+					thumb.image.onerror = function (data) {
+						thumb.loadingDeferred.resolve(null);
+					};
+					var width = square ? 200 : 400;
+					thumb.image.src = Gallery.utility.buildGalleryUrl('preview', '/' + id, {width: width, height: 200}) + '&requesttoken=' + encodeURIComponent(oc_requesttoken);
+				});
 			}
 
 			return batch;

--- a/lib/Controller/PreviewController.php
+++ b/lib/Controller/PreviewController.php
@@ -114,6 +114,7 @@ class PreviewController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 *
 	 * Sends either a large preview of the requested file or the original file itself
 	 *

--- a/lib/Controller/PreviewController.php
+++ b/lib/Controller/PreviewController.php
@@ -137,7 +137,10 @@ class PreviewController extends Controller {
 		}
 		$preview['name'] = $file->getName();
 
-		return new ImageResponse($preview, $status);
+		$response = new ImageResponse($preview, $status);
+		$response->setETag($file->getEtag());
+		$response->cacheFor(3600 * 24);
+		return $response;
 	}
 
 }

--- a/lib/Controller/PreviewPublicController.php
+++ b/lib/Controller/PreviewPublicController.php
@@ -44,6 +44,7 @@ class PreviewPublicController extends PreviewController {
 	/**
 	 * @PublicPage
 	 * @UseSession
+	 * @NoCSRFRequired
 	 *
 	 * Shows a large preview of a file
 	 *


### PR DESCRIPTION
Fixes: #245

Licence: AGPL

### Description

Move from EventSources to individual requests for loading thumbnails.


### Features

### Screenshots or screencasts

### Caveats

## Tests

### Test plan
<!--
Add each test which should be performed and give a general description of the context
You can also link to one or more entries from the "Acceptance tests" section in the wiki
-->

 
### Tested on

- [ ] Windows/Firefox
- [ ] Android 6.1/Chrome

### TODO

- [x] Implement proper thumbnail route with ETag support for gallery (maybe we can use the servers preview endpoint, but I need to check that one handles public shared links)
  - This would also allow us to fix https://github.com/nextcloud/gallery/issues/14
- [x] Test more image formats
- [ ] Remove EventSource code

### Check list

- [ ] Code is properly documented
- [ ] Code is properly formatted
- [ ] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required

### Reviewers


