### PR TITLE
Fixes the gallery app width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -84,6 +84,7 @@ div.crumb.last a {
 	 * controls to be stuck while scrolling. The server sets "height: 100%" for
 	 * the app, so that value has to be overriden. */
 	height: auto;
+	width: 100%;
 }
 
 #gallery.hascontrols {


### PR DESCRIPTION
Sets the gallery app width to 100%.

Closes https://github.com/nextcloud/server/issues/10458
Closes #455