### PR TITLE
Bind scroll event to window

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -58,7 +58,7 @@ $(document).ready(function () {
 		});
 
 		// This block loads new rows
-		$('html, #content-wrapper').scroll(function () {
+		$(window).scroll(function () {
 			Gallery.view.loadVisibleRows(Gallery.albumMap[Gallery.currentAlbum]);
 		});
 


### PR DESCRIPTION
Fixes: #459 

Licence: MIT or AGPL

### Description

Like in the filelist app binding the scroll event to $(window) works. This fixes #459 and enables app loading more than the initially loaded images.

## Tests

### Test plan
Open a folder in gallery with many pictures ( > 100). Try to scroll down and check if all images are loaded.
 
### Tested on

- [x] Mac/Firefox
- [x] Mac/Chrome
- [x] Mac/Safari
- [x] Android 8/Chrome
- [x] iOS/Chrome
