### PR TITLE
Add HEIC/HEIF support to the gallery

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -52,6 +52,8 @@ class ConfigService extends FilesService {
 		'image/bmp',
 		'image/tiff',
 		'image/x-dcraw',
+		'image/heic',
+		'image/heif',
 		'application/x-photoshop',
 		'application/illustrator',
 		'application/postscript',


### PR DESCRIPTION
Requires:
 - https://github.com/nextcloud/server/pull/10827
 - https://github.com/nextcloud/server/pull/10801
 - https://github.com/nextcloud/server/pull/10526

Fixes: https://github.com/owncloud/gallery/issues/737

Licence: AGPL

### Description
This is just adding the mime type for apple iPhone HEIC files to the $baseMimeTypes 


### Features

* renders HEIC files as thumbnails and in the slideshow

### Screenshots or screencasts

### Caveats

* needs nextcloud 14

## Tests

### Test plan
- Upload a test image
- Make sure it gets rendered as a thumbnail in gallery
- Make sure it gets rendered in slideshow
- Make sure it can be downloaded from slideshow
 
### Tested on

- [X] macOS / Firefox
- [X] macOS / Safari

### TODO

- [ ] Other test-cases (?)

### Check list

- [ ] Code is properly documented
- [ ] Code is properly formatted
- [x] Commits have been squashed
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required

### Reviewers
@MorrisJobke 
@rullzer 
@oparoz 