### PR TITLE
Remove sharing height limit, since it is overwriting the server defaults

### DIFF
--- a/css/share.css
+++ b/css/share.css
@@ -175,12 +175,6 @@ a.showCruds:hover,a.unshare:hover {
 	width: 90%;
 }
 
-.ui-autocomplete { /* limit dropdown height to 4 1/2 entries */
-	max-height:103px;
-	overflow-y:auto;
-	overflow-x:hidden;
-}
-
 .notCreatable {
 	padding-left: 12px;
 	padding-top: 12px;


### PR DESCRIPTION
This PR removes the share select height limit which was overwriting the styles from the server in https://github.com/nextcloud/server/pull/11899