### PR TITLE
Hide button if download links are hidden for link shares

### DIFF
--- a/js/slideshowcontrols.js
+++ b/js/slideshowcontrols.js
@@ -139,7 +139,10 @@
 			if (transparent) {
 				this._showBackgroundToggle();
 			}
-			this.showButton('.downloadImage');
+			var hideDownload = $('#hideDownload').val();
+			if (hideDownload !== 'true') {
+				this.showButton('.downloadImage');
+			}
 			var canDelete = ((permissions & OC.PERMISSION_DELETE) !== 0);
 			var canShare = ((permissions & OC.PERMISSION_SHARE) !== 0);
 			if (!isPublic && canDelete) {


### PR DESCRIPTION
This will hide the download button for public link shares if the "Hide download" sharing option is set.

Requires https://github.com/nextcloud/server/pull/12531