### PR TITLE
Quick fix for new files OperationProgressbar

### DIFF
--- a/js/galleryview.js
+++ b/js/galleryview.js
@@ -311,9 +311,15 @@
 			if (!$uploadEl.exists()) {
 				return;
 			}
+
+			this._operationProgressBar = new OCA.Files.OperationProgressBar();
+			this._operationProgressBar.render();
+			$('#content').find('#uploadprogresswrapper').replaceWith(this._operationProgressBar.$el);
+
 			this._uploader = new OC.Uploader($uploadEl, {
 				fileList: FileList,
-				dropZone: $('#content')
+				dropZone: $('#content'),
+				progressBar: this._operationProgressBar
 			});
 			this._uploader.on('add', function (e, data) {
 				data.targetDir = '/' + Gallery.currentAlbum;

--- a/js/merged.json
+++ b/js/merged.json
@@ -1,7 +1,10 @@
 [
-  "app.js",
+  "upload-helper.js",
+  "vendor/bigshot/bigshot-compressed.js",
   "vendor/jquery-touch-events/src/1.0.8/jquery.mobile-events.min.js",
   "vendor/jquery.ui.touch-punch-custom.js",
+  "vendor/modified-eventsource-polyfill/eventsource-polyfill.js",
+  "vendor/commonmark/dist/commonmark.min.js",
   "gallery.js",
   "templates.js",
   "galleryutility.js",
@@ -13,16 +16,13 @@
   "galleryrow.js",
   "galleryimage.js",
   "thumbnail.js",
-  "vendor/modified-eventsource-polyfill/eventsource-polyfill.js",
   "eventsource.js",
   "vendor/nextcloud/share.js",
-  "vendor/commonmark/dist/commonmark.min.js",
   "vendor/dompurify/src/purify.js",
-  "vendor/bigshot/bigshot-compressed.js",
   "slideshow.js",
   "slideshowcontrols.js",
   "slideshowzoomablepreview.js",
-  "upload-helper.js",
   "vendor/nextcloud/newfilemenu.js",
-  "newfilemenuplugins.js"
+  "newfilemenuplugins.js",
+  "app.js"
 ]

--- a/js/upload-helper.js
+++ b/js/upload-helper.js
@@ -217,5 +217,5 @@ var Files = {
 	}
 };
 
-OCA.Files = Files;
-OCA.Files.App.fileList = FileList;
+OCA.Files = Object.assign({}, OCA.Files, Files);
+OCA.Files.App.fileList = Object.assign({}, OCA.Files.App.fileList, FileList);

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -7,7 +7,9 @@
  */
 script(
 	$_['appName'],
-	'merged'
+	[
+		'upload-helper',
+	]
 );
 script(
 	'files',
@@ -18,6 +20,12 @@ script(
 		'operationprogressbar',
 		'templates',
 		'semaphore'
+	]
+);
+script(
+	$_['appName'],
+	[
+		'merged'
 	]
 );
 style(

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -15,6 +15,9 @@ script(
 		'upload',
 		'file-upload',
 		'jquery.fileupload',
+		'operationprogressbar',
+		'templates',
+		'semaphore'
 	]
 );
 style(


### PR DESCRIPTION
With the new OperationProgressbar the gallery app was not loading properly as the required scripts from the files app were missing.

I'm not to happy with all the files app dependencies in here, but this at least brings the gallery app back to being functional.