### PR TITLE
Blacklist using .noimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gallery 
+# Gallery
 [![Build Status](https://travis-ci.org/nextcloud/gallery.svg?branch=master)](https://travis-ci.org/nextcloud/gallery)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/gallery/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/gallery/?branch=master)
 [![Code Coverage](https://codecov.io/gh/nextcloud/gallery/branch/master/graph/badge.svg)](https://codecov.io/gh/nextcloud/gallery)
@@ -20,7 +20,7 @@ Provides a dedicated view of all images in a grid, adds image viewing capabiliti
 * A la carte features (external shares, browser svg rendering, etc.)
 * Image download and sharing straight from the slideshow or the gallery
 * Switch to Gallery from any folder in files and vice-versa
-* Ignore folders containing a ".nomedia" file
+* Ignore folders containing a ".nomedia" or ".noimage" file
 * Browser rendering of SVG images (disabled by default)
 * Mobile support
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
 
 		- Switch to Gallery from any folder in files and vice-versa
 
-		- Ignore folders containing a ".nomedia" file
+		- Ignore folders containing a ".nomedia" or ".noimage" file
 
 		- Browser rendering of SVG images (disabled by default)
 
@@ -55,4 +55,3 @@
 		<developer>https://github.com/nextcloud/gallery/wiki</developer>
 	</documentation>
 </info>
-

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -159,7 +159,7 @@ class ConfigService extends FilesService {
 	public function getConfig($folderNode, $features) {
 		$this->features = $features;
 		list ($albumConfig, $ignored) =
-			$this->collectConfig($folderNode, $this->ignoreAlbum, $this->configName);
+			$this->collectConfig($folderNode, $this->ignoreAlbumStrings, $this->configName);
 		if ($ignored) {
 			throw new ForbiddenServiceException(
 				'The owner has placed a restriction or the storage location is unavailable'
@@ -238,7 +238,7 @@ class ConfigService extends FilesService {
 	 * reached the root folder
 	 *
 	 * @param Folder $folder the current folder
-	 * @param string $ignoreAlbum name of the file which blacklists folders
+	 * @param array $ignoreAlbumStrings names of the files which blacklist folders
 	 * @param string $configName name of the configuration file
 	 * @param int $level the starting level is 0 and we add 1 each time we visit a parent folder
 	 * @param array $configSoFar the configuration collected so far
@@ -246,18 +246,20 @@ class ConfigService extends FilesService {
 	 * @return array <null|array,bool>
 	 */
 	private function collectConfig(
-		$folder, $ignoreAlbum, $configName, $level = 0, $configSoFar = []
+		$folder, $ignoreAlbumStrings, $configName, $level = 0, $configSoFar = []
 	) {
-		if ($folder->nodeExists($ignoreAlbum)) {
-			// Cancel as soon as we find out that the folder is private or external
-			return [null, true];
+		foreach ($ignoreAlbumStrings as $ignoreAlbum) {
+			if ($folder->nodeExists($ignoreAlbum)) {
+				// Cancel as soon as we find out that the folder is private or external
+				return [null, true];
+			}
 		}
 		$isRootFolder = $this->isRootFolder($folder, $level);
 		if ($folder->nodeExists($configName)) {
 			$configSoFar = $this->buildFolderConfig($folder, $configName, $configSoFar, $level);
 		}
 		if (!$isRootFolder) {
-			return $this->getParentConfig($folder, $ignoreAlbum, $configName, $level, $configSoFar);
+			return $this->getParentConfig($folder, $ignoreAlbumStrings, $configName, $level, $configSoFar);
 		}
 		$configSoFar = $this->validatesInfoConfig($configSoFar);
 
@@ -345,7 +347,7 @@ class ConfigService extends FilesService {
 	 * We will look up to the virtual root of a shared folder, for privacy reasons
 	 *
 	 * @param Folder $folder the current folder
-	 * @param string $privacyChecker name of the file which blacklists folders
+	 * @param string $privacyChecker names of the files which blacklist folders
 	 * @param string $configName name of the configuration file
 	 * @param int $level the starting level is 0 and we add 1 each time we visit a parent folder
 	 * @param array $collectedConfig the configuration collected so far

--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -148,6 +148,7 @@ abstract class FilesService extends Service {
 				foreach ($this->ignoreAlbumStrings as $ignoreAlbum) {
 					if ($node->nodeExists($ignoreAlbum)) {
 						$ignored = true;
+						break;
 					}
 				}
 				if (!$ignored) {

--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -29,7 +29,7 @@ abstract class FilesService extends Service {
 	/** @var string[] */
 	protected $features;
 	/** @var string[] */
-	protected $ignoreAlbumStrings = array('.nomedia', '.noimage');
+	protected $ignoreAlbumStrings = ['.nomedia', '.noimage'];
 
 	/**
 	 * Retrieves all files and sub-folders contained in a folder
@@ -141,19 +141,15 @@ abstract class FilesService extends Service {
 	 * @return array|Folder
 	 */
 	protected function getAllowedSubFolder($node, $nodeType) {
-		$ignored = false;
 		if ($nodeType === 'dir') {
 			/** @var Folder $node */
 			try {
 				foreach ($this->ignoreAlbumStrings as $ignoreAlbum) {
 					if ($node->nodeExists($ignoreAlbum)) {
-						$ignored = true;
-						break;
+						return [];
 					}
 				}
-				if (!$ignored) {
-					return [$node];
-				}
+				return [$node];
 			} catch (StorageNotAvailableException $e) {
 				return [];
 			}

--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -28,8 +28,8 @@ abstract class FilesService extends Service {
 	protected $virtualRootLevel = null;
 	/** @var string[] */
 	protected $features;
-	/** @var string */
-	protected $ignoreAlbum = '.nomedia';
+	/** @var string[] */
+	protected $ignoreAlbumStrings = array('.nomedia', '.noimage');
 
 	/**
 	 * Retrieves all files and sub-folders contained in a folder
@@ -141,10 +141,16 @@ abstract class FilesService extends Service {
 	 * @return array|Folder
 	 */
 	protected function getAllowedSubFolder($node, $nodeType) {
+		$ignored = false;
 		if ($nodeType === 'dir') {
 			/** @var Folder $node */
 			try {
-				if (!$node->nodeExists($this->ignoreAlbum)) {
+				foreach ($this->ignoreAlbumStrings as $ignoreAlbum) {
+					if ($node->nodeExists($ignoreAlbum)) {
+						$ignored = true;
+					}
+				}
+				if (!$ignored) {
 					return [$node];
 				}
 			} catch (StorageNotAvailableException $e) {


### PR DESCRIPTION
Fixes: #438 

Licence: MIT or AGPL

### Description
Supports blacklisting folders by creating a `.noimage` file.


### Features

* `.noimage` functionality

### Screenshots or screencasts

### Caveats

## Tests
Tested on my system

### Test plan
 
### Tested on

- [X] Windows/Firefox
- [X] Android 6.1/Chrome

### TODO

### Check list

- [X] Code is properly documented
- [X] Code is properly formatted
- [X] Commits have been squashed
- [x] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required

### Reviewers
