### PR TITLE
🐛 FIX: sharing confirm Button

### DIFF
--- a/css/share.css
+++ b/css/share.css
@@ -47,9 +47,10 @@
 }
 
 #dropdown .shareWithConfirm {
-	padding: 11px;
-	right: 17px;
-	top: 18px;
+	padding: 5px;
+	right: 14px;
+	top: 14px;
+	background-color: transparent !important;
 }
 
 #app-content #dropdown .shareWithConfirm {


### PR DESCRIPTION
removes the background (which was overlapping the border of the input field) and moves the arrow a little bit up
![image](https://user-images.githubusercontent.com/22591354/60178987-ef220080-981c-11e9-8f9b-0bce7892b14f.png)
