### PR TITLE
Add WEBP support to gallery

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -54,6 +54,7 @@ class ConfigService extends FilesService {
 		'image/x-dcraw',
 		'image/heic',
 		'image/heif',
+		'image/webp',
 		'application/x-photoshop',
 		'application/illustrator',
 		'application/postscript',


### PR DESCRIPTION
Licence: AGPL

### Description

This PR adds the mime type `image/webp` to the list of supported image types for the gallery.

This allows that webp images are shown in the gallery.