### PR TITLE
Fix gallery sorting buttons and remove filelist ref  #16076

### DIFF
--- a/css/gallerybutton.css
+++ b/css/gallerybutton.css
@@ -10,8 +10,7 @@
 }
 
 #controls .button.view-switcher.gallery {
-	margin-right: 4px;
-	padding: 9px 11px;
+	display: none;
 }
 
 .icon-toggle-pictures.hidden {

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -51,6 +51,16 @@ style(
 	<div id='breadcrumbs'></div>
 	<div class="actions creatable">
 		<div class="left">
+		</div>
+		<div id="uploadprogresswrapper">
+			<div id="uploadprogressbar"></div>
+			<button class="stop icon-close" style="display:none">
+			<span class="hidden-visually">
+				<?php p($l->t('Cancel upload')) ?>
+			</span>
+			</button>
+		</div>
+		<div class="right">
 			<!-- sorting buttons -->
 			<div id="sort-name-button" class="button sorting left-switch-button">
 				<div class="flipper">
@@ -72,16 +82,6 @@ style(
 					); ?>" alt="<?php p($l->t('Sort by date')); ?>"/>
 				</div>
 			</div>
-		</div>
-		<div id="uploadprogresswrapper">
-			<div id="uploadprogressbar"></div>
-			<button class="stop icon-close" style="display:none">
-			<span class="hidden-visually">
-				<?php p($l->t('Cancel upload')) ?>
-			</span>
-			</button>
-		</div>
-		<div class="right">
 			<!-- sharing button -->
 			<div id="shared-button" class="button">
 				<img class="svg" src="<?php print_unescaped(


### PR DESCRIPTION
Ref: https://github.com/nextcloud/server/issues/16076
>Sort buttons to right and fix layout issues
>Remove "File list" icon in top right