### PR TITLE
Center sort buttons

### DIFF
--- a/css/gallerybutton.css
+++ b/css/gallerybutton.css
@@ -18,14 +18,13 @@
 }
 
 #controls .button.sorting {
-	padding: 8px 7px;
+	padding: 3px 4px 5px 4px !important;
 	-webkit-perspective: 1000px;
 	-moz-perspective: 1000px;
 	perspective: 1000px;
 }
 
-#controls .button.left-switch-button,
-#controls .button.left-switch-button:hover {
+#controls .button.left-switch-button {
 	display: inline;
 	border-radius: 3px 0 0 3px;
 	margin-right: 0;


### PR DESCRIPTION
Fixes [496](https://github.com/nextcloud/gallery/issues/496).

### Description

The sort button icons have been off-center for the last few versions of Nextcloud. This fixes the centering problem.

### Screenshots

Before this fix, the icons look like this:

![before](https://user-images.githubusercontent.com/13763029/66454551-2916bb80-ea36-11e9-9caf-adeed2b18303.png)

After this fix, the icons look like this:

![after](https://user-images.githubusercontent.com/13763029/66454567-32078d00-ea36-11e9-9f76-ab915ae3787c.png)

Also, the left icon no longer shifts after the hover animation as it used to.

## Tested on

- [✓] Chrome 77.0.3865.90
- [✓] Firefox 69.0.2