### PR TITLE
Force close all tooltips when closing sharing menu

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -495,7 +495,8 @@
 									.tooltip('hide')
 									.tooltip({
 										placement: 'bottom',
-										trigger: 'manual'
+										trigger: 'manual',
+										trackTooltip: true
 									})
 									.tooltip('fixTitle')
 									.tooltip('show');
@@ -805,6 +806,7 @@
 		 */
 		hideDropDown: function (callback) {
 			this.currentShares = null;
+			$('[data-original-title]').tooltip('hide');
 			$('#dropdown').slideUp(OC.menuSpeed, function () {
 				Gallery.Share.droppedDown = false;
 				$('#dropdown').remove();


### PR DESCRIPTION
![Gallery app Share option ballon tooltip (2)](https://user-images.githubusercontent.com/14975046/66456518-2768ea00-ea6e-11e9-8cf8-c5d6798a147d.PNG)
![Gallery app Share option ballon tooltip not dissapearing (2)](https://user-images.githubusercontent.com/14975046/66456519-2768ea00-ea6e-11e9-8f92-cc2ca803b80a.PNG)
