### PR TITLE
[stable17] Append the autocomplete results to the dropdown container

### DIFF
--- a/js/vendor/nextcloud/share.js
+++ b/js/vendor/nextcloud/share.js
@@ -448,6 +448,7 @@
 				$('#shareWith').autocomplete({
 					minLength: 2,
 					delay: 750,
+					appendTo: '#dropdown',
 					source: function (search, response) {
 						var $shareWithField = $('#dropdown #shareWith');
 						var $loading = $('#dropdown .shareWithLoading');


### PR DESCRIPTION
Steps to reproduce:
- Go to gallery
- Share a file with a user
- See no results showing up when searching

When trying to share withing the gallery app the autocomplete suggestions were hidden, as they were added to the body and therefore overlayed by the main slideshow which was a z-index of 10000. Appending it to the dropdown makes it use the existing styles for overlaying in https://github.com/nextcloud/gallery/blob/8776be97909c288934b673842fef78c2cd314b32/css/slideshow.css#L190-L193